### PR TITLE
Enable regex matching in valid url templates for http renderer

### DIFF
--- a/lib/windshaft/renderers/http/factory.js
+++ b/lib/windshaft/renderers/http/factory.js
@@ -2,12 +2,7 @@ var Renderer = require('./renderer');
 var FallbackRenderer = require('./fallback_renderer');
 
 function HttpFactory(whitelist, timeout, proxy, fallbackImage) {
-    whitelist = whitelist || [];
-    // key => value with urlTemplate => true for quick access
-    this.whitelist = whitelist.reduce(function(acc, urlTemplate) {
-        acc[urlTemplate] = true;
-        return acc;
-    }, {});
+    this.whitelist = whitelist || [];
 
     this.timeout = timeout;
     this.proxy = proxy;
@@ -43,5 +38,9 @@ HttpFactory.prototype.getRenderer = function(mapConfig, dbParams, format, layerN
 };
 
 function isValidUrlTemplate(urlTemplate, whitelist) {
-    return whitelist[urlTemplate];
+    return whitelist.some(function(currentValue) {
+        return urlTemplate.match(currentValue);
+    });
 }
+
+module.exports.isValidUrlTemplate = isValidUrlTemplate;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "redis": "~0.8.3"
     },
     "scripts": {
-        "test": "sh ./run_tests.sh ${RUNTESTFLAGS} test/unit/*.js test/acceptance/*.js"
+        "test": "sh ./run_tests.sh ${RUNTESTFLAGS} test/unit/*.js test/unit/renderers/*.js test/acceptance/*.js"
     },
     "engines" : {
         "node": ">=0.8 <0.11",

--- a/test/unit/renderers/http_factory.test.js
+++ b/test/unit/renderers/http_factory.test.js
@@ -1,0 +1,54 @@
+var assert = require('assert');
+var HttpRendererFactory = require('../../../lib/windshaft/renderers/http/factory');
+
+suite('renderer_http_factory', function() {
+
+    var validUrlTemplate = 'http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
+    var anotherValidUrlTemplate = 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png';
+
+    var anySRegexUrlTemplate = 'http://(.*).basemaps.cartocdn.com/dark_all/(.*)/(.*)/(.*).png';
+    var curlySRegexUrlTemplate = 'http://{(.)}.basemaps.cartocdn.com/light_nolabels/(.*)/(.*)/(.*).png';
+
+    var invalidUrlTemplate = 'http://wadus.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
+
+    var whitelistSample = [
+        validUrlTemplate,
+        anotherValidUrlTemplate
+    ];
+
+    var regexWhitelistSample = [
+        anySRegexUrlTemplate,
+        curlySRegexUrlTemplate
+    ];
+
+    test('valid urlTemplate', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(validUrlTemplate, whitelistSample), true);
+        done();
+    });
+
+    test('valid REGEX urlTemplate no curly braces', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(validUrlTemplate, regexWhitelistSample), true);
+        done();
+    });
+
+    test('valid REGEX urlTemplate with curly brace match', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(anotherValidUrlTemplate, regexWhitelistSample), true);
+        done();
+    });
+
+    test('invalid urlTemplate', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(invalidUrlTemplate, whitelistSample), false);
+        done();
+    });
+
+    test.skip('invalid urlTemplate no curly braces', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(invalidUrlTemplate, regexWhitelistSample), false);
+        done();
+    });
+
+    test('invalid urlTemplate with curly brace match', function(done) {
+        assert.equal(HttpRendererFactory.isValidUrlTemplate(invalidUrlTemplate, [curlySRegexUrlTemplate]), false);
+        done();
+    });
+
+});


### PR DESCRIPTION
- it's backwards compatible, although it is no longer O(1) (it doesn't matter!)
- there is an skipped test because we want to solve that before enabling it