### PR TITLE
Properly use bash instead of sh

### DIFF
--- a/scripts/check-node-canvas.sh
+++ b/scripts/check-node-canvas.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     CAIRO_PKG_CONFIG=`pkg-config cairo --cflags-only-I 2> /dev/null`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig


### PR DESCRIPTION
The Bourne shell doesn't support `[[` and throws errors when not executed under bash.

I found this bug by running `make` in the root project directory in Ubuntu 14.04 in the last released version, but I see that the shell is being set in the `Makefile` now. This no longer affects `make`, but should still be corrected.

```console
vagrant@vagrant-ubuntu-trusty-64:~/Windshaft$ ./scripts/install.sh
./scripts/install.sh: 3: ./scripts/install.sh: [[: not found
```