### PR TITLE
Add global.environment variables to readme_server.js

### DIFF
--- a/examples/readme_server.js
+++ b/examples/readme_server.js
@@ -5,6 +5,15 @@
 
 var Windshaft = require('../lib/windshaft');
 var _         = require('underscore');
+
+// Force 'test' environment
+var ENV = 'test';
+
+// set environment specific variables
+global.settings     = require('../config/settings');
+global.environment  = require('../config/environments/' + ENV);
+_.extend(global.settings, global.environment);
+
 var config = {
     base_url: '/database/:dbname/table/:table',
     base_url_notable: '/database/:dbname',


### PR DESCRIPTION
This uses the same pattern from `test/performance/test_server.js` to set `global.environment`.

Resolves #288 