### PR TITLE
Torque server side renderer using buffer-size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-# Version 0.38.3
+# Version 0.39.0
 2015-mm-dd
+
+New features:
+ - Allow buffer-size in torque server side rendering (#292)
 
 Bugfixes:
  - Support for torque heatmaps server side rendering (#294)

--- a/lib/windshaft/renderers/torque/png_renderer.js
+++ b/lib/windshaft/renderers/torque/png_renderer.js
@@ -6,11 +6,20 @@ var carto = require('carto');
 var request = require('request');
 
 function PngRenderer(layer, sql, attrs) {
-    Renderer.apply(this, [layer, sql, attrs]);
-
     var cartoCssOptions = torque.common.TorqueLayer.optionsFromCartoCSS(layer.options.cartocss);
+    var rendererOptions = {
+        bufferSize: cartoCssOptions['buffer-size'] !== undefined ? cartoCssOptions['buffer-size'] : 32
+    };
 
-    this.provider = new torque.providers.windshaft(_.extend({ no_fetch_map: true }, cartoCssOptions));
+    Renderer.apply(this, [layer, sql, attrs, rendererOptions]);
+
+    this.provider = new torque.providers.windshaft(_.extend(
+        {
+            no_fetch_map: true,
+            coordinates_data_type: torque.types.Int16Array
+        },
+        cartoCssOptions
+    ));
     this.rendererOptions = _.extend({}, layer.options, cartoCssOptions, {
         canvasClass: Canvas,
         imageClass: Canvas.Image,

--- a/lib/windshaft/renderers/torque/renderer.js
+++ b/lib/windshaft/renderers/torque/renderer.js
@@ -79,14 +79,22 @@ Renderer.prototype = {
 
             var buffer = buffer_size / 2;
 
-            var xmin = -origin_shift + x*tile_geo_size - (pixres * buffer);
-            var xmax = -origin_shift + (x+1)*tile_geo_size + (pixres * buffer);
+            var xmin = -origin_shift + x*tile_geo_size;
+            var xmax = -origin_shift + (x+1)*tile_geo_size;
 
             // tile coordinate system is y-reversed so ymin is the top of the tile
-            var ymin = origin_shift - y*tile_geo_size + (pixres * buffer);
-            var ymax = origin_shift - (y+1)*tile_geo_size - (pixres * buffer);
+            var ymin = origin_shift - y*tile_geo_size;
+            var ymax = origin_shift - (y+1)*tile_geo_size;
             return {
-                xmin: xmin, ymin: ymin, xmax: xmax, ymax: ymax, buffersize: buffer / attrs.resolution
+                xmin: xmin,
+                ymin: ymin,
+                xmax: xmax,
+                ymax: ymax,
+                b_xmin: xmin - (pixres * buffer),
+                b_ymin: ymin + (pixres * buffer),
+                b_xmax: xmax + (pixres * buffer),
+                b_ymax: ymax - (pixres * buffer),
+                b_size: buffer / attrs.resolution
             };
         }
 
@@ -95,12 +103,13 @@ Renderer.prototype = {
                 "WITH innerpar AS (" +
                     "SELECT " +
                         "1.0/(({xyz_resolution})*{resolution}) as resinv, " +
+                        "ST_MakeEnvelope({b_xmin}, {b_ymin}, {b_xmax}, {b_ymax}, {srid}) as b_ext, " +
                         "ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}, {srid}) as ext" +
                 ") " +
                 "SELECT " +
                     "({xyz_resolution})*{resolution} as res, " +
                     "innerpar.resinv as resinv, " +
-                    "innerpar.ext as ext, " +
+                    "innerpar.b_ext as b_ext, " +
                     "st_xmin(innerpar.ext) as xmin, " +
                     "st_ymin(innerpar.ext) as ymin, " +
                     "round((st_xmax(innerpar.ext) - st_xmin(innerpar.ext))*innerpar.resinv) - 1 as maxx, " +
@@ -113,15 +122,12 @@ Renderer.prototype = {
                  "array_agg(d) dates__uint16 " +
             "FROM ( " +
             "select " +
-               "GREATEST(0, LEAST(p.maxx, round((st_x(i.{gcol}) - p.xmin)*resinv))) - {buffersize} as xx, " +
-               "GREATEST(0, LEAST(p.maxy, round((st_y(i.{gcol}) - p.ymin)*resinv))) - {buffersize} as yy " +
+               "GREATEST(0 - {b_size}, LEAST(p.maxx + {b_size}, round((st_x(i.{gcol}) - p.xmin)*resinv))) as xx, " +
+               "GREATEST(0 - {b_size}, LEAST(p.maxy + {b_size}, round((st_y(i.{gcol}) - p.ymin)*resinv))) as yy " +
                ", {countby} c " +
                ", floor(({column_conv} - {start})/{step}) d " +
                 "FROM ({_sql}) i, par p " +
-                // We expand the extent by half the resolution
-                // to include points that would fall within the
-                // extent on grid snapping
-                "WHERE i.{gcol} && p.ext " +
+                "WHERE i.{gcol} && p.b_ext " +
                 stepFilter(attrs) +
             "GROUP BY xx, yy, d  " +
             ") cte, par  " +

--- a/lib/windshaft/renderers/torque/renderer.js
+++ b/lib/windshaft/renderers/torque/renderer.js
@@ -86,7 +86,7 @@ Renderer.prototype = {
             var ymin = origin_shift - y*tile_geo_size + (pixres * buffer);
             var ymax = origin_shift - (y+1)*tile_geo_size - (pixres * buffer);
             return {
-                xmin: xmin, ymin: ymin, xmax: xmax, ymax: ymax, buffersize: buffer_size / 2 / attrs.resolution
+                xmin: xmin, ymin: ymin, xmax: xmax, ymax: ymax, buffersize: buffer / attrs.resolution
             };
         }
 

--- a/lib/windshaft/renderers/torque/renderer.js
+++ b/lib/windshaft/renderers/torque/renderer.js
@@ -4,13 +4,16 @@ var format = require('../../utils/format');
 //
 /// A renderer for a given MapConfig layer
 ///
-function Renderer(layer, sql, attrs) {
+function Renderer(layer, sql, attrs, options) {
+    options = options || {};
+
     this.sql = sql;
     this.attrs = attrs;
     this.layer = layer;
-    //TODO: take defaults as parameters
-    this.tile_size = 256;
-    this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
+
+    this.tile_size = options.tileSize || 256;
+    this.tile_max_geosize = options.maxGeosize || 40075017; // earth circumference in webmercator 3857
+    this.buffer_size = options.bufferSize || 0;
 }
 
 module.exports = Renderer;
@@ -57,6 +60,7 @@ Renderer.prototype = {
         }
 
         var tile_size = this.tile_size;
+        var buffer_size = this.buffer_size;
         var tile_max_geosize = this.tile_max_geosize;
         var geom_column = this.layer.options.geom_column || 'the_geom_webmercator';
         var geom_column_srid = this.layer.options.srid || 3857;
@@ -73,14 +77,16 @@ Renderer.prototype = {
             var pixres = initial_resolution / Math.pow(2,z);
             var tile_geo_size = tile_size * pixres;
 
-            var xmin = -origin_shift + x*tile_geo_size;
-            var xmax = -origin_shift + (x+1)*tile_geo_size;
+            var buffer = buffer_size / 2;
+
+            var xmin = -origin_shift + x*tile_geo_size - (pixres * buffer);
+            var xmax = -origin_shift + (x+1)*tile_geo_size + (pixres * buffer);
 
             // tile coordinate system is y-reversed so ymin is the top of the tile
-            var ymin = origin_shift - y*tile_geo_size;
-            var ymax = origin_shift - (y+1)*tile_geo_size;
+            var ymin = origin_shift - y*tile_geo_size + (pixres * buffer);
+            var ymax = origin_shift - (y+1)*tile_geo_size - (pixres * buffer);
             return {
-                xmin: xmin, ymin: ymin, xmax: xmax, ymax: ymax
+                xmin: xmin, ymin: ymin, xmax: xmax, ymax: ymax, buffersize: buffer_size / 2 / attrs.resolution
             };
         }
 
@@ -107,8 +113,8 @@ Renderer.prototype = {
                  "array_agg(d) dates__uint16 " +
             "FROM ( " +
             "select " +
-               "GREATEST(0, LEAST(p.maxx, round((st_x(i.{gcol}) - p.xmin)*resinv))) as xx, " +
-               "GREATEST(0, LEAST(p.maxy, round((st_y(i.{gcol}) - p.ymin)*resinv))) as yy " +
+               "GREATEST(0, LEAST(p.maxx, round((st_x(i.{gcol}) - p.xmin)*resinv))) - {buffersize} as xx, " +
+               "GREATEST(0, LEAST(p.maxy, round((st_y(i.{gcol}) - p.ymin)*resinv))) - {buffersize} as yy " +
                ", {countby} c " +
                ", floor(({column_conv} - {start})/{step}) d " +
                 "FROM ({_sql}) i, par p " +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "0.38.3",
+    "version": "0.39.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [

--- a/test/acceptance/blend.js
+++ b/test/acceptance/blend.js
@@ -37,6 +37,7 @@ suite('blend png renderer', function() {
                             "where the_geom && ST_MakeEnvelope(-90, 0, 90, 65)",
                         cartocss: [
                             'Map {',
+                            '    buffer-size:0;',
                             '    -torque-frame-count:1;',
                             '    -torque-animation-duration:30;',
                             '    -torque-time-attribute:"cartodb_id";',

--- a/test/acceptance/torque_png.js
+++ b/test/acceptance/torque_png.js
@@ -31,6 +31,7 @@ suite('torque png renderer', function() {
                         " && ST_MakeEnvelope(-90, 0, 90, 65)",
                     cartocss: [
                         'Map {',
+                        '    buffer-size:0;',
                         '    -torque-frame-count:1;',
                         '    -torque-animation-duration:30;',
                         '    -torque-time-attribute:"cartodb_id";',
@@ -101,6 +102,7 @@ suite('torque png renderer', function() {
                     sql: "SELECT * FROM populated_places_simple_reduced",
                     cartocss: [
                         'Map {',
+                        'buffer-size:0;',
                         '-torque-frame-count:1;',
                         '-torque-animation-duration:30;',
                         '-torque-time-attribute:"cartodb_id";',


### PR DESCRIPTION
As tiles in server are rendered individually some features that belong to a
tile in {x: 0, y: 0} but are close to the edge should be rendered in also in
tile, let's say, {x: 1, y: 0} however that last time won't have the data
because it is outside of its bounding box. Adding a bit of buffer to the
bounding box allows to render those features from others' tiles data.

Torque's windshaft provider uses by default a Uint8Array for the coordinates
so it is not possible to represent values different than 0..255 that's why we
force the use of Int16Array to be able to represent negative numbers and values
bigger than 255.

The torque renderer now accepts an options parameter that allows to setup the
buffer size for the query, by default it uses buffer-size=0. So existing users
will keep the previous behaviour.

The PngRenderer will use the provided value through Map{} for the buffer-size
or a default value of buffer-size=32.

The torque query changes to take into account the buffer size. When a value for
the buffer-size is provided the query will *pan* the values based on it. It also
takes care of the resolution to *pan* based on it.

Changes existing tests to use buffer-size=0 so they keep the old behaviour.

Closes #292