### PR TITLE
Remove trailing whitespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -420,7 +420,7 @@ Enhancements:
  Enhancements:
 
  - Do not send 0 timings to statsd (fixes "Bad line: 0,ms" messages)
- - Do not call req2params more then once on MapConfig creation (#157) 
+ - Do not call req2params more then once on MapConfig creation (#157)
  - Do not invalidate renderer caches when NO cache_buster is given (#158)
  - Call afterLayergroupCreate only after MapConfig verification (#159)
  - Drop LRU cache for "seen" layergroups (#160)
@@ -512,7 +512,7 @@ Enhancements:
 
  Bug fixes:
 
- - Fix coordinate order in TorqueRenderer.getTile 
+ - Fix coordinate order in TorqueRenderer.getTile
 
 # Version 0.16.0
 2014-02-04
@@ -619,7 +619,7 @@ Enhancements:
 2013-08-13
 
  - Rewrite mapnik XML parsing error to start with style name (#73)
- - Fix error on empty CartoCSS 
+ - Fix error on empty CartoCSS
 
 # Version 0.13.1
 2013-07-18
@@ -648,7 +648,7 @@ Enhancements:
 2013-06-28
 
  - Allow setting layergroup token ttl via config variable
-   grainstore.default_layergroup_ttl 
+   grainstore.default_layergroup_ttl
  - Only check layergroup configuration when first seen (#77)
  - Use tile 30/0/0 for testing layergroups, override with maxzoom (#78)
 
@@ -712,7 +712,7 @@ Enhancements:
    - Drop  /layergroup/:token/:z/:x/:y.grid.json route
    - Add /layergroup/:token/:layer/:z/:x/:y.grid.json route
    - Add /layergroup route to create maps via GET (#69)
-   - Add map config to afterLayergroupCreate hook signature 
+   - Add map config to afterLayergroupCreate hook signature
 
 # Version 0.10.0
 2013-03-29
@@ -842,7 +842,7 @@ Enhancements:
 # Version 0.5.5
 2012-08-07
 
- - Use custom tilelive-mapnik to workaround ever-growing memory use 
+ - Use custom tilelive-mapnik to workaround ever-growing memory use
  - Expose setStyle and delStyle methods
  - Add afterStyleChange and afterStyleDelete callbacks
 
@@ -858,11 +858,11 @@ Enhancements:
 This release drops the requirement of a field already in epsg:3857
 (aka "the_geom_webmercator");
 
- - Raise grainstore dependency to ~0.3.1 to allow for safe 
+ - Raise grainstore dependency to ~0.3.1 to allow for safe
    wgs84 to webmercator reprojection in mapnik.
  - Update tests to use mapnik reprojection.
  - Improve testing tool to accept tolerances
- - Shrinkwrap carto 0.8.1 and mapnik-reference 3.1.0 
+ - Shrinkwrap carto 0.8.1 and mapnik-reference 3.1.0
 
 # Version 0.5.2
 2012-07-20
@@ -873,7 +873,7 @@ This release drops the requirement of a field already in epsg:3857
 # Version 0.5.1
 2012-07-12
 
- - Raise underscore dependency to ~1.3 
+ - Raise underscore dependency to ~1.3
  - Loosen grainstore dependency to >= 0.2.3 < 0.4
  - Loosen hiredis dependency to ~0.1.12
 
@@ -882,7 +882,7 @@ This release drops the requirement of a field already in epsg:3857
 
  NOTE: this release drops support for node-0.4.x
 
- - Requires node-0.6 (#10) 
+ - Requires node-0.6 (#10)
  - Add npm-shrinkwrap.json file to lock dependencies versions
  - Add support for mapnik 2.1.x (#14)
  - Stop depending on the tilelive-mapnik-cartodb fork of tilelive-mapnik (#26)
@@ -913,7 +913,7 @@ This release drops the requirement of a field already in epsg:3857
    - Do not hang anymore
    - Fix invalid MML syntax
    - More verbose failures
- - Improved documentation 
+ - Improved documentation
  - Raise grainstore dependency to 0.2.2
 
 # Version 0.4.6

--- a/doc/MapConfig-1.1.0.md
+++ b/doc/MapConfig-1.1.0.md
@@ -1,6 +1,6 @@
 # 1. Purpose
 
-This specification describes 
+This specification describes
 [MapConfig](MapConfig-specification) format version 1.1.0.
 
 
@@ -48,13 +48,13 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                // REQUIRED
                // string, SQL to be performed on user database to fetch the data to be rendered.
                //
-               // It should select at least the columns specified in ``geom_column``, 
+               // It should select at least the columns specified in ``geom_column``,
                // ``interactivity`` and  ``attributes`` configurations below.
                //
                // For ``mapnik`` layers it can contain substitution tokens !bbox!,
-               // !pixel_width! and !pixel_height!, see implication of that in the 
+               // !pixel_width! and !pixel_height!, see implication of that in the
                // ``attributes`` configuration below.
-               // 
+               //
                sql: 'select * from table',
 
                // OPTIONAL
@@ -92,7 +92,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                // string array, contains fields renderer inside grid.json
                // all the params should be exposed by the results of executing the query in sql attribute
                interactivity: [ 'field1', 'field2', .. ]
-               
+
                // OPTIONAL
                // values returned by attributes service (disabled if no config is given)
                // NOTE: enabling the attribute service is forbidden if the "sql" option contains
@@ -100,7 +100,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                attributes: {
                  // REQUIRED
                  // used as key value to fetch columns
-                 id: 'identifying_column', 
+                 id: 'identifying_column',
 
                  // REQUIRED
                  // string list of columns returned by attributes service

--- a/doc/MapConfig-1.2.0.md
+++ b/doc/MapConfig-1.2.0.md
@@ -1,6 +1,6 @@
 # 1. Purpose
 
-This specification describes 
+This specification describes
 [MapConfig](MapConfig-specification) format version 1.2.0.
 
 
@@ -48,13 +48,13 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                // REQUIRED
                // string, SQL to be performed on user database to fetch the data to be rendered.
                //
-               // It should select at least the columns specified in ``geom_column``, 
+               // It should select at least the columns specified in ``geom_column``,
                // ``interactivity`` and  ``attributes`` configurations below.
                //
                // For ``mapnik`` layers it can contain substitution tokens !bbox!,
-               // !pixel_width! and !pixel_height!, see implication of that in the 
+               // !pixel_width! and !pixel_height!, see implication of that in the
                // ``attributes`` configuration below.
-               // 
+               //
                sql: 'select * from table',
 
                // OPTIONAL
@@ -105,7 +105,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                // string array, contains fields renderer inside grid.json
                // all the params should be exposed by the results of executing the query in sql attribute
                interactivity: [ 'field1', 'field2', .. ]
-               
+
                // OPTIONAL
                // values returned by attributes service (disabled if no config is given)
                // NOTE: enabling the attribute service is forbidden if the "sql" option contains
@@ -113,7 +113,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
                attributes: {
                  // REQUIRED
                  // used as key value to fetch columns
-                 id: 'identifying_column', 
+                 id: 'identifying_column',
 
                  // REQUIRED
                  // string list of columns returned by attributes service

--- a/examples/viewer/leaflet.css
+++ b/examples/viewer/leaflet.css
@@ -2,16 +2,16 @@
 
 .leaflet-map-pane,
 .leaflet-tile,
-.leaflet-marker-icon, 
+.leaflet-marker-icon,
 .leaflet-marker-shadow,
-.leaflet-tile-pane, 
+.leaflet-tile-pane,
 .leaflet-overlay-pane,
 .leaflet-shadow-pane,
 .leaflet-marker-pane,
 .leaflet-popup-pane,
 .leaflet-overlay-pane svg,
 .leaflet-zoom-box,
-.leaflet-image-layer { /* TODO optimize classes */ 
+.leaflet-image-layer { /* TODO optimize classes */
 	position: absolute;
 	}
 .leaflet-container {
@@ -20,14 +20,14 @@
 .leaflet-tile-pane {
 	-webkit-transform: translate3d(0,0,0);
 	}
-.leaflet-tile, 
-.leaflet-marker-icon, 
+.leaflet-tile,
+.leaflet-marker-icon,
 .leaflet-marker-shadow {
 	-moz-user-select: none;
 	-webkit-user-select: none;
 	user-select: none;
 	}
-.leaflet-marker-icon, 
+.leaflet-marker-icon,
 .leaflet-marker-shadow {
 	display: block;
 	}
@@ -79,7 +79,7 @@ a.leaflet-active {
 	}
 .leaflet-bottom {
 	bottom: 0;
-	}	
+	}
 .leaflet-left {
 	left: 0;
 	}
@@ -141,12 +141,12 @@ a.leaflet-active {
 .leaflet-control-zoom-out {
 	background-image: url(images/zoom-out.png);
 	}
-	
+
 .leaflet-control-layers {
 	-moz-box-shadow: 0 0 7px #999;
 	-webkit-box-shadow: 0 0 7px #999;
 	box-shadow: 0 0 7px #999;
-	
+
 	background: #f8f8f9;
 	}
 .leaflet-control-layers a {
@@ -189,12 +189,12 @@ a.leaflet-active {
 .leaflet-container .leaflet-control-attribution {
 	margin: 0;
 	padding: 0 5px;
-	
+
 	font: 11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
 	color: #333;
-	
+
 	background-color: rgba(255, 255, 255, 0.7);
-            
+
 	-moz-box-shadow: 0 0 7px #ccc;
 	-webkit-box-shadow: 0 0 7px #ccc;
 	box-shadow: 0 0 7px #ccc;
@@ -205,7 +205,7 @@ a.leaflet-active {
 
 .leaflet-fade-anim .leaflet-tile {
 	opacity: 0;
-	
+
 	-webkit-transition: opacity 0.2s linear;
 	-moz-transition: opacity 0.2s linear;
 	-o-transition: opacity 0.2s linear;
@@ -264,9 +264,9 @@ a.leaflet-active {
 	width: 15px;
 	height: 15px;
 	padding: 1px;
-	
+
 	margin: -8px auto 0;
-	
+
 	-moz-transform: rotate(45deg);
 	-webkit-transform: rotate(45deg);
 	-ms-transform: rotate(45deg);
@@ -277,10 +277,10 @@ a.leaflet-active {
 	position: absolute;
 	top: 9px;
 	right: 9px;
-	
+
 	width: 10px;
 	height: 10px;
-	
+
 	overflow: hidden;
 	}
 .leaflet-popup-content p {
@@ -303,13 +303,13 @@ a.leaflet-active {
 	}
 .leaflet-popup-content-wrapper, .leaflet-popup-tip {
 	background: white;
-	
+
 	box-shadow: 0 1px 10px #888;
 	-moz-box-shadow: 0 1px 10px #888;
 	 -webkit-box-shadow: 0 1px 14px #999;
 	}
 .leaflet-popup-content-wrapper {
-	-moz-border-radius: 20px; 
+	-moz-border-radius: 20px;
 	-webkit-border-radius: 20px;
 	border-radius: 20px;
 	}

--- a/examples/viewer/leaflet.ie.css
+++ b/examples/viewer/leaflet.ie.css
@@ -7,11 +7,11 @@
 	height: 1px;
 	}
 .lvml {
-	behavior: url(#default#VML); 
-	display: inline-block; 
+	behavior: url(#default#VML);
+	display: inline-block;
 	position: absolute;
 	}
-	
+
 .leaflet-control {
 	display: inline;
 	}
@@ -21,7 +21,7 @@
 	_width: 27px;
 	margin: 0 auto;
 	_margin-top: -3px;
-	
+
 	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	}

--- a/lib/windshaft/models/mapconfig.js
+++ b/lib/windshaft/models/mapconfig.js
@@ -98,7 +98,7 @@ o.layerType = function(num) {
   return typ;
 };
 
-/// API: Get layer by index 
+/// API: Get layer by index
 //
 /// @returns undefined on invalid index
 ///

--- a/lib/windshaft/renderers/README
+++ b/lib/windshaft/renderers/README
@@ -3,14 +3,14 @@ Renderers are expected to expose the following interfaces:
   /// Get a tile given ZXY params
   //
   /// @param z zoom level
-  /// @param x 
-  /// @param y 
+  /// @param x
+  /// @param y
   /// @param callback function(err, tileobj, meta)
   ///   - 'err' will be an instance of Error on any problem, or null.
-  ///   - 'tileobj' will be an opaque object 
+  ///   - 'tileobj' will be an opaque object
   ///   - 'meta' will contain info about 'tileobj', like:
   ///     * 'Content-Type' mime-type of the tile, for example:
-  ///                      'image/png', 'text/javascript; charset=utf-8', 
+  ///                      'image/png', 'text/javascript; charset=utf-8',
   ///
   getTile(z, x, y, callback)
 
@@ -26,7 +26,7 @@ Renderers are expected to expose the following interfaces:
 They are created by renderer factories having the following
 interface:
 
-  /// Create a renderer given a map and data store configuration 
+  /// Create a renderer given a map and data store configuration
   //
   /// @param mapConfig map configuration, see
   ///        http://github.com/CartoDB/Windshaft/wiki/MapConfig-specification
@@ -38,7 +38,7 @@ interface:
   ///
   getRenderer(mapConfig, dbParams, format, layer, callback)
 
-  /// Destroy a renderer 
+  /// Destroy a renderer
   //
   /// Disposed renderers should not be used anymore
   ///

--- a/lib/windshaft/renderers/render_cache.js
+++ b/lib/windshaft/renderers/render_cache.js
@@ -80,10 +80,10 @@ module.exports = function(options, mml_store, map_store, mapnik_opts, rendererFa
     //        ready for you to use (calling getTile or getGrid).
     //        Note that the object is a proxy to the actual TileStore
     //        so you won't get the whole TileLive interface available.
-    //        If you need that, use the .get() function.        
+    //        If you need that, use the .get() function.
     //        In order to reduce memory usage call renderer.release()
     //        when you're sure you won't need it anymore.
-    //                 
+    //
     //
     me.getRenderer = function(req, callback) {
 

--- a/lib/windshaft/renderers/torque/factory.js
+++ b/lib/windshaft/renderers/torque/factory.js
@@ -144,7 +144,7 @@ function attrsFromCartoCSS(cartocss, required) {
 //
 // get rules from Map definition
 // stores errors in env.error
-// 
+//
 function getMapProperties(definitions, env) {
   var rules = {};
   definitions.filter(function(r) {
@@ -161,7 +161,7 @@ function getMapProperties(definitions, env) {
 
 //
 // check layer and raise an exception is some error is found
-// 
+//
 // @throw Error if missing or malformed CartoCSS
 //
 function _checkLayerAttributes(layerConfig) {
@@ -175,7 +175,7 @@ function _checkLayerAttributes(layerConfig) {
 
 // returns an array of errors if the mapconfig is not supported or contains errors
 // errors is empty is the configuration is ok
-// dbParams: host, dbname, user and pass 
+// dbParams: host, dbname, user and pass
 // layer: optional, if is specified only a layer is checked
 function fetchMapConfigAttributes(sql, mapConfig, dbParams, layer_id, callback) {
 
@@ -269,7 +269,7 @@ function fetchLayerAttributes(sql, layer_sql, attrs, callback) {
   // prepare metadata needed to render the tiles
   //
   function generateMetadata(err, data) {
-    if(err) { 
+    if(err) {
       if ( err.message ) {
           err.message = 'TorqueRenderer: ' + err.message;
       }

--- a/lib/windshaft/server.js
+++ b/lib/windshaft/server.js
@@ -92,7 +92,7 @@ module.exports = function(opts){
         : new RedisPool(_.extend(opts.redis, {name: 'windshaft:server'}));
 
     // initialize core mml_store
-    var mml_store_opts = { pool: redisPool }; 
+    var mml_store_opts = { pool: redisPool };
     // force GC off, we'll purge localized resources ourselves
     // NOTE: this is not needed anymore with grainstore-0.18.0
     opts.grainstore.gc_prob = 0;
@@ -220,7 +220,7 @@ module.exports = function(opts){
         afterStateChange: function(req, data, callback) {
             callback(null, data);
         },
-        // called after a map style is changed 
+        // called after a map style is changed
         afterStyleChange: function(req, data, callback) {
             this.afterStateChange(req, data, callback);
         },
@@ -376,7 +376,7 @@ module.exports = function(opts){
           tolog = err;
       }
       var log_msg = olabel + " -- " + statusCode + ": " + tolog;
-      //if ( tolog.stack ) log_msg += "\n" + tolog.stack; 
+      //if ( tolog.stack ) log_msg += "\n" + tolog.stack;
       console.error(log_msg); // use console.log for statusCode != 500 ?
       // If a callback was requested, force status to 200
       if ( res.req ) {

--- a/lib/windshaft/storages/mapstore.js
+++ b/lib/windshaft/storages/mapstore.js
@@ -5,7 +5,7 @@ var RedisPool  = require('redis-mpool');
 var _          = require('underscore');
 var MapConfig  = require('../models/mapconfig');
 
-/// API: Create MapStore 
+/// API: Create MapStore
 //
 /// @param opts configuration options
 ///

--- a/test/README.md
+++ b/test/README.md
@@ -11,7 +11,7 @@ Requirements
    Used to drive the test runs
    You can install globally using ```npm install -g mocha```
  * Redis - http://redis.io/
-   Used to cache styles 
+   Used to cache styles
  * ImageMagick - http://www.imagemagick.org
    Compare tool is used to perform image comparison
 
@@ -29,7 +29,7 @@ PostgreSQL 9.1+ needs to be running, listening on a TCP port and be
 accessible as specified in the environment configuration.
 
 Create a spatial database called "windshaft_test" and load the script
-fixtures/windshaft.test.sql to initialize it. 
+fixtures/windshaft.test.sql to initialize it.
 The script ```./prepare_test``` attempts to do all of it for you.
 Note that if running mapnik < 2.0.2, the spatial DB must be loaded with
 a version of PostGIS providing 'AsBinary' and friends (including legacy.sql

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -53,7 +53,7 @@ suite('attributes', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           if ( err ) { done(err); return; }
           assert.equal(matches.length, 0, "redis keys present at setup time:\n" + matches.join("\n"));
@@ -65,7 +65,7 @@ suite('attributes', function() {
     test("can only be fetched from layer having an attributes spec",
     function(done) {
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -194,7 +194,7 @@ suite('attributes', function() {
 
     test("can be used with jsonp", function(done) {
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -278,7 +278,7 @@ suite('attributes', function() {
         ", test_table_inserter(st_setsrid(st_point(0,0),4326),'write') as w";
       mapconfig.layers[1].options.attributes.columns.push('w');
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -42,14 +42,14 @@ suite('multilayer', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           assert.equal(matches.length, 0, "redis keys present at setup time:\n" + matches.join("\n"));
       });
 
       // Start a server to test external resources
       res_serv = http.createServer( function(request, response) {
-          var filename = __dirname + '/../fixtures/markers' + request.url; 
+          var filename = __dirname + '/../fixtures/markers' + request.url;
           fs.readFile(filename, "binary", function(err, file) {
             if ( err ) {
               response.writeHead(404, {'Content-Type': 'text/plain'});
@@ -111,7 +111,7 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select the_geom from test_table limit 1',
-               cartocss: '#layer { marker-fill:red }', 
+               cartocss: '#layer { marker-fill:red }',
                cartocss_version: '2.0.1'
              } }
         ]
@@ -156,7 +156,7 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, 1 as n, the_geom, !bbox! as b from test_table limit 1',
-               cartocss: '#layer { marker-fill:red }', 
+               cartocss: '#layer { marker-fill:red }',
                cartocss_version: '2.0.1',
                attributes: { id:'cartodb_id', columns:['n'] }
              } }
@@ -195,12 +195,12 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select st_setsrid(st_makepoint(0, 0), 4326) as the_geom',
-               cartocss: '#layer { marker-fill:red; } #layer { marker-width:100; }', 
+               cartocss: '#layer { marker-fill:red; } #layer { marker-width:100; }',
                cartocss_version: '2.0.1'
              } }
         ]
       };
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -257,20 +257,20 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: [ 'cartodb_id' ]
              } },
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, -50, 0) as the_geom from test_table limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: [ 'cartodb_id' ]
              } }
         ]
       };
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -364,20 +364,20 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: [ 'cartodb_id' ]
              } },
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, -50, 0) as the_geom from test_table limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: [ 'cartodb_id' ]
              } }
         ]
       };
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_get()
         {
@@ -474,13 +474,13 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: [ 'cartodb_id' ]
              } },
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, -50, 0) as the_geom from test_table limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: [ 'cartodb_id' ]
              } }
@@ -583,13 +583,13 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: [ 'cartodb_id' ]
              } },
            { options: {
                sql: 'select cartodb_id, cartodb_id*10 as n, ST_Translate(the_geom, -50, 0) as the_geom from test_table ORDER BY cartodb_id limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: [ 'cartodb_id' ],
                attributes: { id: 'cartodb_id', columns: ['n'] }
@@ -757,7 +757,7 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
              } }
         ]
       };
@@ -781,7 +781,7 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: 'cartodb_id'
              } }
@@ -793,7 +793,7 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, -50, 0) as the_geom from test_table limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: 'cartodb_id'
              } }
@@ -1067,7 +1067,7 @@ suite('multilayer', function() {
           var parsed = JSON.parse(res.body);
           assert.ok(parsed);
           assert.equal(parsed.errors.length, 1);
-          var error = parsed.errors[0]; 
+          var error = parsed.errors[0];
           assert.ok(error.match(/column "missing" does not exist/m), error);
           // TODO: check which layer introduced the problem ?
           done();
@@ -1104,7 +1104,7 @@ suite('multilayer', function() {
           var parsed = JSON.parse(res.body);
           assert.ok(parsed);
           assert.equal(parsed.errors.length, 1);
-          var error = parsed.errors[0]; 
+          var error = parsed.errors[0];
           assert.ok(error.match(/^style1: CartoCSS is empty/), error);
           done();
         } catch (err) { done(err); }
@@ -1138,7 +1138,7 @@ suite('multilayer', function() {
           var parsed = JSON.parse(res.body);
           assert.ok(parsed);
           assert.equal(parsed.errors.length, 1);
-          var error = parsed.errors[0]; 
+          var error = parsed.errors[0];
           // carto-0.9.3 used to say "Failed to parse expression",
           // carto-0.9.5 says "not a valid keyword"
           assert.ok(error.match(/^style0:.*(Failed|not a valid)/), error);
@@ -1435,20 +1435,20 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, 50, 0) as the_geom from test_table limit 2',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1',
                interactivity: [ 'cartodb_id' ]
              } },
            { options: {
                sql: 'select cartodb_id, ST_Translate(the_geom, -50, 0) as the_geom from test_table limit 2 offset 2',
-               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:blue; marker-allow-overlap:true; }',
                cartocss_version: '2.0.2',
                interactivity: [ 'cartodb_id' ]
              } }
         ]
       };
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -1493,12 +1493,12 @@ suite('multilayer', function() {
         layers: [
            { options: {
                sql: 'select 1 as i, 2::int2 as n, now() as t, ST_SetSRID(ST_MakePoint(0,0),3857) as the_geom',
-               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }', 
+               cartocss: '#layer { marker-fill:red; marker-width:32; marker-allow-overlap:true; }',
                cartocss_version: '2.0.1'
              } }
         ]
       };
-      var token1, token2; 
+      var token1, token2;
       Step(
         function do_post_1()
         {

--- a/test/acceptance/raster.js
+++ b/test/acceptance/raster.js
@@ -38,7 +38,7 @@ suite('raster', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           if ( err ) { done(err); return; }
           assert.equal(matches.length, 0, "redis keys present at setup time:\n" + matches.join("\n"));
@@ -63,7 +63,7 @@ suite('raster', function() {
              } }
         ]
       };
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {

--- a/test/acceptance/server.js
+++ b/test/acceptance/server.js
@@ -59,7 +59,7 @@ suite('server', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
 
         if ( err ) { done(err); return; }
@@ -71,7 +71,7 @@ suite('server', function() {
         // Start a server to test external resources
         res_serv = http.createServer( function(request, response) {
             ++res_serv_status.numrequests;
-            var filename = __dirname + '/../fixtures/markers' + request.url; 
+            var filename = __dirname + '/../fixtures/markers' + request.url;
             fs.readFile(filename, "binary", function(err, file) {
               if ( err ) {
                 response.writeHead(404, {'Content-Type': 'text/plain'});
@@ -194,7 +194,7 @@ suite('server', function() {
     });
 
     ////////////////////////////////////////////////////////////////////
-    // 
+    //
     // OPTIONS TILE
     //
     ////////////////////////////////////////////////////////////////////
@@ -266,7 +266,7 @@ suite('server', function() {
             data: querystring.stringify({style: '#test_table_2{backgxxxxxround-color:#fff;}'})
         },{
             status: 400,
-            body: /Unrecognized rule: backgxxxxxround-color/ 
+            body: /Unrecognized rule: backgxxxxxround-color/
         }, function() { done(); } );
     });
 
@@ -278,7 +278,7 @@ suite('server', function() {
             data: querystring.stringify({style: '#test_table_2{backgxxxxxround-color:#fff;foo:bar}'})
         },{
             status: 400,
-            body: /Unrecognized rule: backgxxxxxround-color.*Unrecognized rule: foo/ 
+            body: /Unrecognized rule: backgxxxxxround-color.*Unrecognized rule: foo/
         }, function() { done(); } );
     });
 
@@ -370,7 +370,7 @@ suite('server', function() {
             assert.equal(res.statusCode, 200, res.body);
             var parsed = JSON.parse(res.body);
             assert.equal(parsed.style, style);
-            // specified is retained 
+            // specified is retained
             assert.equal(parsed.style_version, '2.0.2');
             next(null);
           });
@@ -386,7 +386,7 @@ suite('server', function() {
             assert.equal(res.statusCode, 200, res.body);
             var parsed = JSON.parse(res.body);
             assert.equal(parsed.style, style);
-            // specified is retained 
+            // specified is retained
             assert.equal(parsed.style_version, mapnik_version);
             next(null);
           });
@@ -418,7 +418,7 @@ suite('server', function() {
             // NOTE: no conversion expected for the specific style (may change)
             assert.equal(parsed.style, style);
             // Style converted to target
-            assert.equal(parsed.style_version, mapnik_version); 
+            assert.equal(parsed.style_version, mapnik_version);
             done();
           });
         }
@@ -427,7 +427,7 @@ suite('server', function() {
 
     ////////////////////////////////////////////////////////////////////
     //
-    // GET GRID 
+    // GET GRID
     //
     ////////////////////////////////////////////////////////////////////
 
@@ -738,7 +738,7 @@ suite('server', function() {
       // Check that we left the redis db empty
       redis_client.keys("*", function(err, matches) {
           if ( err ) errors.push(err);
-          try { 
+          try {
             assert.equal(matches.length, 0, "Left over redis keys:\n" + matches.join("\n"));
           } catch (err) {
             errors.push(err);
@@ -746,7 +746,7 @@ suite('server', function() {
 
           var cachedir = global.environment.millstone.cache_basedir;
           rmdir_recursive_sync(cachedir);
-              
+
           redis_client.flushall(function() {
             done(errors.length ? new Error(errors) : null);
           });

--- a/test/acceptance/server_gettile.js
+++ b/test/acceptance/server_gettile.js
@@ -45,7 +45,7 @@ suite('server_gettile', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
 
         if ( err ) { done(err); return; }
@@ -57,7 +57,7 @@ suite('server_gettile', function() {
         // Start a server to test external resources
         res_serv = http.createServer( function(request, response) {
             ++res_serv_status.numrequests;
-            var filename = __dirname + '/../fixtures/markers' + request.url; 
+            var filename = __dirname + '/../fixtures/markers' + request.url;
             fs.readFile(filename, "binary", function(err, file) {
               if ( err ) {
                 response.writeHead(404, {'Content-Type': 'text/plain'});
@@ -82,7 +82,7 @@ suite('server_gettile', function() {
     // --{
     ////////////////////////////////////////////////////////////////////
 
-    test("get'ing a tile with default style should return an expected tile", 
+    test("get'ing a tile with default style should return an expected tile",
     function(done){
       Step (
         function makeGet() {
@@ -593,7 +593,7 @@ suite('server_gettile', function() {
       );
     });
 
-    test("base and custom style tile referencing external resources do not affect each other", 
+    test("base and custom style tile referencing external resources do not affect each other",
         function(done){
       var style = "#test_table_3{marker-file: url('http://localhost:" + res_serv_port + "/circle.svg'); marker-transform:'scale(0.2)'; }";
       var style2 = "#test_table_3{marker-file: url('http://localhost:" + res_serv_port + "/square.svg'); marker-transform:'scale(0.2)'; }";
@@ -666,7 +666,7 @@ suite('server_gettile', function() {
               });
           });
         },
-        // Now fetch the base style tile again 
+        // Now fetch the base style tile again
         function getBaseTile1(err, data) {
           if ( err ) throw err;
           var next = this;
@@ -692,7 +692,7 @@ suite('server_gettile', function() {
     });
 
     // See http://github.com/CartoDB/Windshaft/issues/107
-    test("external resources get localized on renderer creation", 
+    test("external resources get localized on renderer creation",
         function(done){
       var style = "#test_table_3{marker-file: url('http://localhost:" + res_serv_port + "/square.svg'); marker-transform:'scale(0.2)'; }";
       var stylequery = querystring.stringify({style: style});
@@ -767,7 +767,7 @@ suite('server_gettile', function() {
       );
     });
 
-    test("referencing unexistant external resources returns an error", 
+    test("referencing unexistant external resources returns an error",
         function(done){
       var url = "http://localhost:" + res_serv_port + "/notfound.png";
       var style = "#test_table_3{marker-file: url('" + url + "'); marker-transform:'scale(0.2)'; }";
@@ -818,7 +818,7 @@ suite('server_gettile', function() {
         },
         function check(err, res) {
           if ( err ) throw err;
-          assert.equal(res.statusCode, 400, res.statusCode + ': ' + ( res.statusCode != 200 ? res.body : '..' )); 
+          assert.equal(res.statusCode, 400, res.statusCode + ': ' + ( res.statusCode != 200 ? res.body : '..' ));
           var parsed = JSON.parse(res.body);
           assert.ok(parsed.error);
           var msg = parsed.error;
@@ -959,7 +959,7 @@ suite('server_gettile', function() {
       // Check that we left the redis db empty
       redis_client.keys("*", function(err, matches) {
           if ( err ) errors.push(err);
-          try { 
+          try {
             assert.equal(matches.length, 0, "Left over redis keys:\n" + matches.join("\n"));
           } catch (err) {
             errors.push(err);
@@ -967,7 +967,7 @@ suite('server_gettile', function() {
 
           var cachedir = global.environment.millstone.cache_basedir;
           rmdir_recursive_sync(cachedir);
-              
+
           redis_client.flushall(function() {
             done(errors.length ? new Error(errors) : null);
           });

--- a/test/acceptance/torque.js
+++ b/test/acceptance/torque.js
@@ -36,7 +36,7 @@ suite('torque', function() {
 
     suiteSetup(function(done) {
 
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           if ( err ) { done(err); return; }
           assert.equal(matches.length, 0, "redis keys present at setup time:\n" + matches.join("\n"));
@@ -186,7 +186,7 @@ suite('torque', function() {
         ]
       };
 
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {
@@ -366,7 +366,7 @@ suite('torque', function() {
              } }
         ]
       };
-      var expected_token; 
+      var expected_token;
       Step(
         function do_post()
         {

--- a/test/performance/README
+++ b/test/performance/README
@@ -10,7 +10,7 @@ In order to run the performance test you need:
     field name is also written in the environment file)
 
 How to run the test:
- 
+
  1. Run the server, and put in the background:
     ./test_server.js &
     Will tell you something like: "Windshaft tileserver started on port 8080"
@@ -22,5 +22,5 @@ How to run the test:
     PORT is where tileserver started on.
     DBNAME and TABLENAME are the source of data you want to get tiles of.
     NOTE: you can also add the full url to a tile, including any parameter
-    (api_key, style, sql, ...); the tool will take care of figuring out 
-    the structure of the call for you. 
+    (api_key, style, sql, ...); the tool will take care of figuring out
+    the structure of the call for you.

--- a/test/performance/benchmark.js
+++ b/test/performance/benchmark.js
@@ -39,9 +39,9 @@ var cached_requests = 20;
 var cache_buster_url;
 var N = cached_requests*50; // number of requests (50 full viewports)
 var concurrency = cached_requests; // number of concurrent requests
-var cols = 5;  
+var cols = 5;
 var lines = 4;
-var zlevs = 2; 
+var zlevs = 2;
 var fetch_grid = 0;
 var idletime = 0; // in seconds (TODO: parametrize)
 var timelimit = 0;
@@ -147,7 +147,7 @@ function end() {
     console.log("Zoom levels:          ", zlevs);
     console.log("Start tile:           ", zstart + "/" + xstart + "/" + ystart);
     console.log("Viewports per cache:  ", isNaN(cached_requests) ? 'all' : cached_requests);
-  if ( cache_buster_url ) 
+  if ( cache_buster_url )
     console.log("Cache buster url:     ", cache_buster_url);
     console.log("Simulated users:      ", users);
     console.log("Concurrency Level:    ", concurrency);
@@ -181,7 +181,7 @@ var error = 0;
 http.globalAgent.maxSockets = concurrency;
 
 if ( timelimit ) {
-  setTimeout(function() { 
+  setTimeout(function() {
     console.log("Interrupting after " + timelimit + " seconds");
     end();
   }, timelimit*1000);
@@ -190,7 +190,7 @@ if ( timelimit ) {
 function fetchTileOrGrid(url, callback)
 {
   // Do not send more than the max requests
-  if ( requests_sent >= N ) { callback(); return; } 
+  if ( requests_sent >= N ) { callback(); return; }
   ++requests_sent;
 
   var t = Date.now();
@@ -280,7 +280,7 @@ function fetchViewport(x0, y0, z, cache_buster, callback)
 }
 
 var now = Date.now();
-var cbprefix = 'wb_' + process.env.USER + '_' + process.pid + "_"; 
+var cbprefix = 'wb_' + process.env.USER + '_' + process.pid + "_";
 var vpcount = 0;
 var last_cbserial;
 var last_cb;
@@ -305,7 +305,7 @@ function fetchCacheBusterValue(callback)
       last_cb = cb;
       callback(null, last_cb);
       return;
-    } 
+    }
 
     if ( verbose ) {
       console.log("Cache-buster fetching " + cbserial);
@@ -333,7 +333,7 @@ function fetchNextViewport() {
 
     if ( requests_sent >= N ) end();
 
-    // update zoom level 
+    // update zoom level
     var zdist = ( vpcount % zlevs );
     var z = zstart + zdist;
     var zdist_tiles = (1<<zdist);
@@ -342,7 +342,7 @@ function fetchNextViewport() {
 
 
 
-    // update cache_buster 
+    // update cache_buster
     fetchCacheBusterValue(function(err, cb) {
 
       if ( err ) {

--- a/test/performance/test_server.js
+++ b/test/performance/test_server.js
@@ -20,11 +20,11 @@ ServerOptions.redis.reapIntervalMillis = ServerOptions.redis.idleTimeoutMillis;
 
 var server = new Windshaft.Server(ServerOptions);
 
-// it takes up to 15 file descriptors to support 1 connection 
+// it takes up to 15 file descriptors to support 1 connection
 // the default limit on file descriptors per process is 1024
 // so we allow max 68 connections (this is just an indication
 // and only applies on the code of 29 Jan 2013)
-// 
+//
 server.maxConnections = 68;
 server.listen(global.environment.windshaft_port);
 console.log("Windshaft tileserver started on port " + global.environment.windshaft_port);

--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -281,7 +281,7 @@ assert.utfgridEqualsFile = function(buffer, file_b, tolerance, callback) {
         if ( ncols != ecols.length ) {
           throw new Error( "Obtained grid cols (" + ncols +
                    ") != expected grid cols (" + ecols.length +
-                   ") on row " + i ); 
+                   ") on row " + i );
         }
         for (var j=0; j<ncols; ++j) {
           var ocell = ocols[j];

--- a/test/support/server_options.js
+++ b/test/support/server_options.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var mapnik = require('mapnik');
 
 module.exports = function(opts) {
-    
+
     var config = {
         base_url: '/database/:dbname/table/:table',
         base_url_notable: '/database/:dbname',
@@ -40,7 +40,7 @@ module.exports = function(opts) {
             req.params =  _.extend({}, req.params);
             _.extend(req.params, req.query);
 
-            // increment number of calls counter 
+            // increment number of calls counter
             // NOTE: "this" would likely point to the server instance
             this.req2params_calls = this.req2params_calls ? this.req2params_calls + 1 : 1;
 
@@ -83,6 +83,6 @@ module.exports = function(opts) {
     };
 
     _.extend(config,  opts || {});
- 
+
     return config;
 }();

--- a/test/unit/mapstore.test.js
+++ b/test/unit/mapstore.test.js
@@ -11,12 +11,12 @@ var   _             = require('underscore')
 ;
 
 suite('mapstore', function() {
- 
+
     var redis_client = redis.createClient(serverOptions.redis.port);
     var redis_pool = new RedisPool(serverOptions.redis);
 
     suiteSetup(function(done) {
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           assert.equal(matches.length, 0);
           done();

--- a/test/unit/render_cache.test.js
+++ b/test/unit/render_cache.test.js
@@ -11,7 +11,7 @@ var   _             = require('underscore')
     , tests         = module.exports = {};
 
 suite('render_cache', function() {
- 
+
     var redis_client = redis.createClient(serverOptions.redis.port);
 
     // initialize core mml_store
@@ -33,7 +33,7 @@ suite('render_cache', function() {
 
 
     suiteSetup(function(done) {
-      // Check that we start with an empty redis db 
+      // Check that we start with an empty redis db
       redis_client.keys("*", function(err, matches) {
           assert.equal(matches.length, 0);
           done();
@@ -214,7 +214,7 @@ suite('render_cache', function() {
         }};
         render_cache.getRenderer(req, function(err, renderer){
             assert.ok(renderer, err);
-            // This is an attempt at finding a value for "dbuser" which 
+            // This is an attempt at finding a value for "dbuser" which
             // is not the empty string but still works at connecting to
             // the database. Failure to connect would result in the
             // renderer not staying in the cache, as per
@@ -286,7 +286,7 @@ suite('render_cache', function() {
         render_cache.getRenderer(req, function(err, renderer){
             assert.ok(err);
             // Need next tick as the renderer is removed from
-            // the cache after the callback is invoked 
+            // the cache after the callback is invoked
             setTimeout(function() {
               err = null;
               try {

--- a/test/unit/torque.test.js
+++ b/test/unit/torque.test.js
@@ -72,7 +72,7 @@ describe('torque', function() {
   beforeEach(function(){
     sqlApi = GenSQL();
     torque = new TorqueFactory({
-      sqlClass: sqlApi 
+      sqlClass: sqlApi
     });
   });
 


### PR DESCRIPTION
I've gone through these by hand and made sure that all tests pass, but it's worth mentioning that this was done automagically with:

``` shell
find . -type f \( \
  -name '*.js' -o -name '*.css' -o -name '*.md' -o -name 'README' \
\) -exec sed --in-place 's/[[:space:]]\+$//' {} \+
```

The only place where I could imagine this being a problem would be [hard line breaks in Markdown](http://spec.commonmark.org/0.17/#hard-line-break), but there aren't any of those in this repo.