### PR TITLE
Authenticate as "test_ws_publicuser" with password

### DIFF
--- a/test/unit/render_cache.test.js
+++ b/test/unit/render_cache.test.js
@@ -212,7 +212,10 @@ describe('render_cache', function() {
             // the database. Failure to connect would result in the
             // renderer not staying in the cache, as per
             // http://github.com/CartoDB/Windshaft/issues/171
-            req.params = requestParams({ dbuser: 'test_ws_publicuser' });
+            req.params = requestParams({
+                dbuser: 'test_ws_publicuser',
+                dbpassword: 'public'
+            });
 
             render_cache.getRenderer(req, function(/*err, renderer*/) {
                 req.params = requestParams({ token: mapConfig2.id() });


### PR DESCRIPTION
Unless the PostgreSQL [host-based authentication configuration](http://www.postgresql.org/docs/9.1/static/auth-pg-hba-conf.html) has a matching record with an auth-mode of [`trust`](http://www.postgresql.org/docs/9.3/static/auth-methods.html#AUTH-TRUST), PostgreSQL throws an authentication failure when trying to connect without a password and [Mocha's equality assertion](https://github.com/CartoDB/Windshaft/blob/09e9d4bfb90aae832b6da5fa048ff389c0489396/test/unit/render_cache.test.js#L221) fails.

Here are the  original errors, caused by the `md5` auth-mode in the `host all all 0.0.0.0/0 md5` record.

![screen shot 2015-04-21 at 6 12 34 pm](https://cloud.githubusercontent.com/assets/537700/7265652/12dcfae0-e852-11e4-8958-321b49b47929.png)

Obligatory stacktrace.

![screen shot 2015-04-21 at 6 12 10 pm](https://cloud.githubusercontent.com/assets/537700/7265653/18db72d2-e852-11e4-9c08-ba9b0966f284.png)

I've read through #59, #171, and mapnik/mapnik#2179 to make sure that `renderer_cache.test.js` wasn't meant to cache the password somehow, but it might be worth having @strk take a look at this to make sure I'm not borking anything.

If you have [Docker](https://docs.docker.com/installation/) and [Compose](https://docs.docker.com/compose/#installation-and-set-up) installed, you can reproduce the test failure with three commands.

``` shell
git clone https://github.com/TerraSeer/steven-tiler.git
cd steven-tiler
docker-compose build && docker-compose up
```

Thanks!