### PR TITLE
Skip layer handler in map controller if token === 'static'

### DIFF
--- a/lib/windshaft/controllers/map.js
+++ b/lib/windshaft/controllers/map.js
@@ -111,7 +111,10 @@ MapController.prototype.tile = function(req, res) {
 };
 
 // Gets a tile for a given token, layer set of tile ZXY coords. (OSM style)
-MapController.prototype.layer = function(req, res) {
+MapController.prototype.layer = function(req, res, next) {
+    if (req.params.token === 'static') {
+        return next();
+    }
     req.profiler.start('windshaft.maplayer_tile');
     this.tileOrLayer(req, res);
 };


### PR DESCRIPTION
that way static controller can handle all URL associated to it