### PR TITLE
Layergroup creation returns metadata for all layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 2015-mm-dd
 
 New features
+ - Layergroup creation returns metadata for all layers (#338)
+   Keeps backwards compatibility for torque metadata
  - Renderer selection based on layer (#336)
    Before the renderer selection was based on the format
    For instance that meant it wasn't possible to request layer in png because that was returning just mapnik layers

--- a/doc/MapConfig-specification.md
+++ b/doc/MapConfig-specification.md
@@ -12,23 +12,8 @@ The identifier of created maps can then be used to fetch different resources
     - Can be of different formats (TODO: href each format...):
         * png
         * grid.json
-        * torque.json, torque.bin, torque.png
-        * http.png
- - Metadata
-   - format dependent on layer.type
-     - mapnik layers: (no metadata)
-     - torque layers:
-```
-{
-    // integer, min value for time column (in millis for time columns of date type)
-    "start": 123123123,
-    // integer, max value for time column (in millis). Must be greater or equal than start
-    "end": 123123124,
-    // integer, animation steps calculated, should be less or equal than -torque-max-steps
-    "steps": 512,
-    // time column type, can be "date" or "number"
-    "columnType": "number"
-}
-```
- - Attributes
-   - Identified by LAYER_NUMBER and FEATURE_ID
+        * torque.json
+  - Static images/previews
+    - With a center or a bounding box
+  - Attributes
+    - Identified by LAYER_NUMBER and FEATURE_ID

--- a/doc/Multilayer-API.md
+++ b/doc/Multilayer-API.md
@@ -131,6 +131,7 @@ The response should be like:
         "layers": [
             // mandatory
             // {String} the type of the renderer, as in a layergroup
+            // Valid types in Windshaft: "mapnik", "torque", "http", "plain"
             "type": "mapnik",
             // mandatory
             // {Object} it will be always present, even if empty

--- a/doc/Multilayer-API.md
+++ b/doc/Multilayer-API.md
@@ -90,7 +90,7 @@ OPTIONS :base_url_mapconfig
 
 Should be a POST to `:base_url_mapconfig` with the layergroup definition in the
 body (content-type application/json) or a GET from `:base_url_mapconfig` with
-the [layergroup definition](MapConfig-specification) in a `config` parameter.
+the [layergroup definition](MapConfig-specification.md) in a `config` parameter.
 
 For example:
 
@@ -123,8 +123,37 @@ The response should be like:
 
 ```
 {
+    // {String} The layergroup identifier that allows to request resources
     "layergroupid": ":TOKEN",
-    "last_updated": "1970-01-01T00:00:00.000Z",
+    // {Object} Metadata associated to the layergroup
+    "metadata": {
+        // {Array} a list of metadata for each layer
+        "layers": [
+            // mandatory
+            // {String} the type of the renderer, as in a layergroup
+            "type": "mapnik",
+            // mandatory
+            // {Object} it will be always present, even if empty
+            "meta": {
+                // as many JSON valid key => value pairs
+                // what you might find here is renderer-specific
+            }
+        ],
+        // torque metadata in case there is at least one torque layer
+        "torque": {
+            // the index of the torque layer inside the layergroup
+            "1": {
+                // {Number} min value for time column (in millis for time columns of date type)
+                "start": 1325372640000,
+                // {Number} max value for time column (in millis). Must be greater or equal than start
+                "end": 1356994560000,
+                // {Number} number of aggregated data steps
+                "data_steps": 145571,
+                // {String} time column type, can be "date" or "number"
+                "column_type": "date"
+            }
+        }
+    }
 }
 ```
 

--- a/lib/windshaft/backends/map.js
+++ b/lib/windshaft/backends/map.js
@@ -197,44 +197,37 @@ MapBackend.prototype.getFeatureAttributes = function(req, res, testMode) {
     );
 };
 
+var metadataTypeToFormat = {
+    mapnik: 'grid.json',
+    torque: 'json.torque'
+};
 
-MapBackend.prototype.getTorqueLayersMetadata = function(req, mapConfig, callback) {
+function getFormatForMetadata(layerType) {
+    return metadataTypeToFormat[layerType] || 'png';
+}
+
+MapBackend.prototype.getLayersMetadata = function(req, mapConfig, callback) {
     var self = this;
 
-    var torqueLayers = [];
+    var layers = mapConfig.getLayers();
 
-    mapConfig.getLayers().forEach(function(layer, layerId) {
-        if (mapConfig.layerType(layerId) === 'torque') {
-            torqueLayers.push(layerId);
-        }
-    });
-
-    if ( ! torqueLayers.length ) {
+    if ( ! layers.length ) {
         return callback(null, null);
     }
 
+    var metadataQueue = queue(layers.length);
 
-    var metadataQueue = queue(torqueLayers.length);
-
-    torqueLayers.forEach(function(layerId) {
-        metadataQueue.defer(function(req, token, rendererType, layerId, done) {
-            self.fetchTilesetMetadata(req, token, rendererType, layerId, done);
-        }, req, mapConfig.id(), 'json.torque', layerId);
+    layers.forEach(function(layer, layerId) {
+        metadataQueue.defer(function(req, token, layerId, done) {
+            var layerType = mapConfig.layerType(layerId);
+            self.getLayerMetadata(req, token, getFormatForMetadata(layerType), layerId, function(err, metadata) {
+                return done(err, { type: layerType, meta: metadata || {} });
+            });
+        }, req, mapConfig.id(), layerId);
     });
 
     function metadataQueueFinish(err, results) {
-        if (err) {
-            return callback(err, results);
-        }
-        if (!results) {
-            return callback(null, null);
-        }
-
-        var metadata = {};
-        torqueLayers.forEach(function(layerId, i) {
-            metadata[layerId] = results[i];
-        });
-        return callback(err, metadata);
+        return callback(err, results || []);
     }
 
     metadataQueue.awaitAll(metadataQueueFinish);
@@ -246,29 +239,25 @@ MapBackend.prototype.getTorqueLayersMetadata = function(req, mapConfig, callback
 /// @param layerId layer index within the mapConfig
 /// @param callback function(err, metadata) where metadata format
 ///
-MapBackend.prototype.fetchTilesetMetadata = function(req, token, rendererType, layerId, callback) {
+MapBackend.prototype.getLayerMetadata = function(req, token, format, layerId, callback) {
     var self = this;
 
     req = _.clone(req);
     req.params = _.clone(req.params);
     req.params.token = token;
-    req.params.format = rendererType;
+    req.params.format = format;
     req.params.layer = layerId;
 
     var renderer;
 
     step(
         function(){
-            self._app.req2params(req, this);
-        },
-        function(err) {
-            assert.ifError(err);
             self._renderCache.getRenderer(req, this);
         },
         function(err, r) {
             assert.ifError(err);
             renderer = r;
-            renderer.get().getMetadata(this);
+            renderer.getMetadata(this);
         },
         function(err, meta) {
             if ( renderer ) {

--- a/lib/windshaft/cache/cache_entry.js
+++ b/lib/windshaft/cache/cache_entry.js
@@ -29,6 +29,10 @@ CacheEntry.prototype.getTile = function(z, x, y, cb) {
     this.renderer.getTile.apply(this.renderer, [z, x, y, cb]);
 };
 
+CacheEntry.prototype.getMetadata = function(z, x, y, cb) {
+    this.renderer.getMetadata.apply(this.renderer, [z, x, y, cb]);
+};
+
 // Get the contained entry
 CacheEntry.prototype.get = function() {
     return this.renderer.get();

--- a/lib/windshaft/models/mapconfig.js
+++ b/lib/windshaft/models/mapconfig.js
@@ -90,12 +90,12 @@ o.layerType = function(num) {
   if ( ! lyr ) {
       return undefined;
   }
-  var typ = lyr.type;
-  if ( ! typ || typ === 'cartodb' ) {
-      typ = 'mapnik';
-  }
-  // TODO: check validity of other types ?
-  return typ;
+  return this.getType(lyr.type);
+};
+
+o.getType = function(type) {
+    // TODO: check validity of other types ?
+    return (!type || type === 'cartodb') ? 'mapnik' : type;
 };
 
 /// API: Get layer by index

--- a/lib/windshaft/renderers/base_adaptor.js
+++ b/lib/windshaft/renderers/base_adaptor.js
@@ -23,6 +23,7 @@ function BaseAdaptor(renderer, format, onTileErrorStrategy) {
             renderer.getTile(z, wrap(x, z), y, callback);
         };
     }
+    this.getMetadata = this.renderer.getMetadata.bind(this.renderer);
     this.get = function() {
         return renderer;
     };

--- a/lib/windshaft/renderers/blend/renderer.js
+++ b/lib/windshaft/renderers/blend/renderer.js
@@ -67,3 +67,7 @@ Renderer.prototype.getTile = function(z, x, y, callback) {
     timer.start('render');
     tileQueue.awaitAll(tileQueueFinish);
 };
+
+Renderer.prototype.getMetadata = function(callback) {
+    return callback(null, {});
+};

--- a/lib/windshaft/renderers/http/fallback_renderer.js
+++ b/lib/windshaft/renderers/http/fallback_renderer.js
@@ -40,6 +40,10 @@ Renderer.prototype.getTile = function(z, x, y, callback) {
     }
 };
 
+Renderer.prototype.getMetadata = function(callback) {
+    return callback(null, {});
+};
+
 function getTileStrategy(fallbackImage, done) {
     switch (fallbackImage.type) {
         case 'fs':

--- a/lib/windshaft/renderers/http/renderer.js
+++ b/lib/windshaft/renderers/http/renderer.js
@@ -62,6 +62,10 @@ Renderer.prototype.getTile = function(z, x, y, callback) {
     return requestImage(requestOpts, callback);
 };
 
+Renderer.prototype.getMetadata = function(callback) {
+    return callback(null, {});
+};
+
 // Following functionality has been extracted directly from Leaflet library
 // License: https://github.com/Leaflet/Leaflet/blob/v0.7.3/LICENSE
 

--- a/lib/windshaft/renderers/mapnik/adaptor.js
+++ b/lib/windshaft/renderers/mapnik/adaptor.js
@@ -27,6 +27,9 @@ function TileliveAdaptor(renderer, format, onTileErrorStrategy) {
     } else {
         throw new Error("Unsupported format " + format);
     }
+    this.getMetadata = function(callback) {
+        return callback(null, {});
+    };
 }
 
 module.exports = TileliveAdaptor;

--- a/lib/windshaft/renderers/plain/renderer.js
+++ b/lib/windshaft/renderers/plain/renderer.js
@@ -59,3 +59,7 @@ Renderer.prototype.getTile = function(z, x, y, callback) {
         this.callbacks.push(callback);
     }
 };
+
+Renderer.prototype.getMetadata = function(callback) {
+    return callback(null, {});
+};

--- a/lib/windshaft/server.js
+++ b/lib/windshaft/server.js
@@ -271,12 +271,12 @@ module.exports = function(opts) {
                     });
                 }
             },
-            function fetchTorqueMetadata(err) {
+            function fetchLayersMetadata(err) {
                 assert.ifError(err);
 
                 var next = this;
 
-                mapBackend.getTorqueLayersMetadata(req, mapConfig, function(err, metadata) {
+                mapBackend.getLayersMetadata(req, mapConfig, function(err, layersMetadata) {
                     if (err) {
                         map_store.del(mapConfig.id(), function(delErr) {
                             if (delErr) {
@@ -285,9 +285,20 @@ module.exports = function(opts) {
                             return next(err);
                         });
                     } else {
-                        if (metadata) {
+                        if (layersMetadata) {
                             response.metadata = response.metadata || {};
-                            response.metadata.torque = metadata;
+                            response.metadata.layers = layersMetadata;
+
+                            // backwards compatibility for torque
+                            var torqueMetadata = layersMetadata.reduce(function(acc, layer, layerId) {
+                                if (layer.type === 'torque') {
+                                    acc[layerId] = layer.meta;
+                                }
+                                return acc;
+                            }, {});
+                            if (Object.keys(torqueMetadata).length) {
+                                response.metadata.torque = torqueMetadata;
+                            }
                         }
                         return next(err);
                     }

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -456,7 +456,18 @@ describe('multilayer', function() {
         function do_check_token(err, res) {
           assert.ifError(err);
           assert.equal(res.statusCode, 200, res.body);
-          assert.equal(res.body, 'jsonp_test(' + JSON.stringify({layergroupid: expected_token, layercount: 2}) + ');');
+          console.log(res.body);
+          assert.equal(res.body, 'jsonp_test(' + JSON.stringify({
+              layergroupid: expected_token,
+              metadata: {
+                  layers: [
+                      { type: "mapnik", "meta":{} },
+                      { type: "mapnik", "meta":{} }
+                  ]
+              },
+              layercount: 2
+          }) + ');');
+
           // TODO: check caching headers !
           return null;
         },

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -456,7 +456,6 @@ describe('multilayer', function() {
         function do_check_token(err, res) {
           assert.ifError(err);
           assert.equal(res.statusCode, 200, res.body);
-          console.log(res.body);
           assert.equal(res.body, 'jsonp_test(' + JSON.stringify({
               layergroupid: expected_token,
               metadata: {

--- a/test/acceptance/multilayer_interactivity.js
+++ b/test/acceptance/multilayer_interactivity.js
@@ -57,6 +57,14 @@ describe('multilayer interactivity and layers order', function() {
                     assert.ok(layergroupId);
                     assert.equal(layergroupResponse.layercount, layergroup.layers.length);
 
+                    // check layers metadata at least match in number
+                    assert.equal(layergroupResponse.metadata.layers.length, layergroup.layers.length);
+                    // check torque metadata at least match in number
+                    var torqueLayers = layergroup.layers.filter(function(layer) { return layer.type === 'torque'; });
+                    if (torqueLayers.length) {
+                        assert.equal(Object.keys(layergroupResponse.metadata.torque).length, torqueLayers.length);
+                    }
+
                     redisClient.exists("map_cfg|" +  layergroupId, function(err, exists) {
                         if (err) {
                             return done(err);

--- a/test/acceptance/multilayer_interactivity.js
+++ b/test/acceptance/multilayer_interactivity.js
@@ -4,6 +4,7 @@ var assert        = require('../support/assert');
 var _             = require('underscore');
 var redis         = require('redis');
 var Windshaft     = require('../../lib/windshaft');
+var getLayerTypeFn = require('../../lib/windshaft/models/mapconfig').prototype.getType;
 var ServerOptions = require('../support/server_options');
 
 describe('multilayer interactivity and layers order', function() {
@@ -58,7 +59,14 @@ describe('multilayer interactivity and layers order', function() {
                     assert.equal(layergroupResponse.layercount, layergroup.layers.length);
 
                     // check layers metadata at least match in number
-                    assert.equal(layergroupResponse.metadata.layers.length, layergroup.layers.length);
+                    var layersMetadata = layergroupResponse.metadata.layers;
+                    assert.equal(layersMetadata.length, layergroup.layers.length);
+                    for (var i = 0, len = layersMetadata.length; i < len; i++) {
+                        assert.equal(
+                            getLayerTypeFn(layersMetadata[i].type),
+                            getLayerTypeFn(layergroup.layers[i].type)
+                        );
+                    }
                     // check torque metadata at least match in number
                     var torqueLayers = layergroup.layers.filter(function(layer) { return layer.type === 'torque'; });
                     if (torqueLayers.length) {

--- a/test/acceptance/torque.js
+++ b/test/acceptance/torque.js
@@ -195,7 +195,9 @@ describe('torque', function() {
           var tm0 = tm[0];
           assert.ok(tm0,
             'No layer 0 in "torque" in metadata:' + JSON.stringify(tm));
-          assert.deepEqual(tm0, {"start":0,"end":86400000,"data_steps":2,"column_type":"date"});
+          var expectedTorqueMetadata = {"start":0,"end":86400000,"data_steps":2,"column_type":"date"};
+          assert.deepEqual(tm0, expectedTorqueMetadata);
+          assert.deepEqual(meta.layers[0].meta, expectedTorqueMetadata);
           return null;
         },
         function do_get_tile(err)


### PR DESCRIPTION
See https://github.com/CartoDB/Windshaft/issues/338

Multilayer-API.md contains information about the changes introduced by this.

Keeps backwards compatibility for torque metadata.