### PR TITLE
Renderer metadata only called for torque layers

### DIFF
--- a/lib/windshaft/backends/map.js
+++ b/lib/windshaft/backends/map.js
@@ -197,37 +197,52 @@ MapBackend.prototype.getFeatureAttributes = function(req, res, testMode) {
     );
 };
 
-var metadataTypeToFormat = {
-    mapnik: 'grid.json',
-    torque: 'json.torque'
-};
-
-function getFormatForMetadata(layerType) {
-    return metadataTypeToFormat[layerType] || 'png';
-}
-
 MapBackend.prototype.getLayersMetadata = function(req, mapConfig, callback) {
     var self = this;
 
-    var layers = mapConfig.getLayers();
+    var metadata = [];
 
-    if ( ! layers.length ) {
-        return callback(null, null);
+    var torqueLayers = [];
+
+    mapConfig.getLayers().forEach(function(layer, layerId) {
+        var layerType = mapConfig.layerType(layerId);
+        metadata[layerId] = {
+            type: layerType,
+            meta: {}
+        };
+
+        if (layerType === 'torque') {
+            torqueLayers.push(layerId);
+        }
+    });
+
+    if ( ! torqueLayers.length ) {
+        return callback(null, metadata);
     }
 
-    var metadataQueue = queue(layers.length);
+    var metadataQueue = queue(torqueLayers.length);
 
-    layers.forEach(function(layer, layerId) {
-        metadataQueue.defer(function(req, token, layerId, done) {
-            var layerType = mapConfig.layerType(layerId);
-            self.getLayerMetadata(req, token, getFormatForMetadata(layerType), layerId, function(err, metadata) {
-                return done(err, { type: layerType, meta: metadata || {} });
-            });
-        }, req, mapConfig.id(), layerId);
+    torqueLayers.forEach(function(layerId) {
+        metadataQueue.defer(function(req, token, rendererType, layerId, done) {
+            self.getLayerMetadata(req, token, rendererType, layerId, done);
+        }, req, mapConfig.id(), 'json.torque', layerId);
     });
 
     function metadataQueueFinish(err, results) {
-        return callback(err, results || []);
+        if (err) {
+            return callback(err, results);
+        }
+        if (!results) {
+            return callback(null, null);
+        }
+
+        torqueLayers.forEach(function(layerId, i) {
+            metadata[layerId] = {
+                type: 'torque',
+                meta: results[i]
+            };
+        });
+        return callback(err, metadata);
     }
 
     metadataQueue.awaitAll(metadataQueueFinish);


### PR DESCRIPTION
That way we avoid the overhead of creating renderers just for metadata

Some notes about renderer creation and RenderCache:
 - getMetadata is a expensive operation because it requires a renderer
 - Renderers are cached in RenderCache
 - Renderer creation and recreation is based on the existence of a key
   in the RenderCache and a cache buster associated to the request and
   if the Renderer already exists
 - MapValidation follows a similar approach but if the MapConfig key
   was already in Redis it does not validate again the map so it does
   not need to create the renderers again. So the number of times the
   validation is actually happening, and thus renderer creation, is
   way lower than metadata use case.
 - Metadata was happening for every single layergroup creation
 - One of the biggest issues is the cache_buster is not set until
   afterLayergroupCreate is called. All renderers created for metadata
   cannot be reused because the cache_buster will be different for the
   following requests.
 - This also happens when a renderer is created for validation as it
   will not be reused for tiles and it will be recreated.