### PR TITLE
Unify error response format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # Version 0.45.0
 2015-mm-dd
 
+Enhancements:
+ - Unifies error response format to `{ "errors": ["messages"] }`
+
 Announcements:
  - Removes LocalizedResourcePurger to avoid issues with cached assets
    See https://github.com/CartoDB/Windshaft/issues/339#issuecomment-104684003

--- a/lib/windshaft/backends/map.js
+++ b/lib/windshaft/backends/map.js
@@ -189,7 +189,7 @@ MapBackend.prototype.getFeatureAttributes = function(req, res, testMode) {
                 // See https://github.com/Vizzuality/Windshaft-cartodb/issues/68
                 var errMsg = err.message ? ( '' + err.message ) : ( '' + err );
                 var statusCode = self._app.findStatusCode(err);
-                self._app.sendError(res, {error: errMsg}, statusCode, 'GET ATTRIBUTES', err);
+                self._app.sendError(res, { errors: [errMsg] }, statusCode, 'GET ATTRIBUTES', err);
             } else {
                 self._app.sendResponse(res, [tile, 200]);
             }

--- a/lib/windshaft/backends/map_validator.js
+++ b/lib/windshaft/backends/map_validator.js
@@ -140,7 +140,7 @@ MapValidatorBackend.prototype.tryFetchFeatureAttributes = function(req, token, l
             if ( statusCode === 200 ) {
                 callback();
             } else {
-                callback(new Error(body.error));
+                callback(new Error(body.errors[0]));
             }
         }
     };

--- a/lib/windshaft/controllers/map.js
+++ b/lib/windshaft/controllers/map.js
@@ -175,7 +175,7 @@ MapController.prototype.finalizeGetTileOrGrid = function(err, req, res, tile, he
             errMsg = 'style'+matches[2]+': ' + matches[1];
         }
 
-        this._app.sendError(res, {error: errMsg}, statusCode, 'TILE RENDER', err);
+        this._app.sendError(res, { errors: ['' + errMsg] }, statusCode, 'TILE RENDER', err);
         global.statsClient.increment('windshaft.tiles.error');
         global.statsClient.increment('windshaft.tiles.' + formatStat + '.error');
     } else {

--- a/lib/windshaft/controllers/static_maps.js
+++ b/lib/windshaft/controllers/static_maps.js
@@ -61,7 +61,7 @@ StaticMapsController.prototype.staticMap = function(req, res, width, height, zoo
                 if (!err.error) {
                     err.error = err.message;
                 }
-                self._app.sendError(res, err, self._app.findStatusCode(err), 'STATIC_MAP', err);
+                self._app.sendError(res, {errors: ['' + err] }, self._app.findStatusCode(err), 'STATIC_MAP', err);
             } else {
                 res.setHeader('Content-Type', headers['Content-Type'] || 'image/' + format);
                 self._app.sendResponse(res, [image, 200]);

--- a/lib/windshaft/server.js
+++ b/lib/windshaft/server.js
@@ -345,7 +345,7 @@ module.exports = function(opts) {
     app.use(function(err, req, res, next) {
         if (err) {
             if (err.name === 'SyntaxError') {
-                app.sendError(res, {error: err.name, msg: err.message}, 400, 'JSON', err);
+                app.sendError(res, { errors: [err.name + ': ' + err.message] }, 400, 'JSON', err);
             } else {
                 next(err);
             }

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -76,7 +76,7 @@ describe('attributes', function() {
           assert.ifError(err);
           assert.equal(res.statusCode, 400, res.statusCode + ( res.statusCode !== 200 ? (': ' + res.body) : '' ));
           var parsed = JSON.parse(res.body);
-          assert.equal(parsed.error, "Layer 0 has no exposed attributes");
+          assert.equal(parsed.errors[0], "Layer 0 has no exposed attributes");
           return null;
         },
         function do_get_attr_1(err)
@@ -108,8 +108,8 @@ describe('attributes', function() {
           assert.ifError(err);
           assert.equal(res.statusCode, 404, res.statusCode + ': ' + res.body);
           var parsed = JSON.parse(res.body);
-          assert.ok(parsed.error);
-          var msg = parsed.error;
+          assert.ok(parsed.errors);
+          var msg = parsed.errors[0];
           assert.ok(msg.match(/0 features.*identified by fid -666/), msg);
           return null;
         },
@@ -162,6 +162,7 @@ describe('attributes', function() {
         },
         function checkPost(err, res) {
           assert.ifError(err);
+            console.log('rochoa', res.statusCode, res.body);
           assert.equal(res.statusCode, 404, res.statusCode + ': ' + (res.statusCode===200?'...':res.body));
           var parsed = JSON.parse(res.body);
           assert.ok(parsed.errors);
@@ -218,7 +219,7 @@ describe('attributes', function() {
           assert.ifError(err);
           // jsonp errors should be returned with HTTP status 200
           assert.equal(res.statusCode, 200, res.statusCode + ': ' + res.body);
-          assert.equal(res.body, 'test({"error":"Layer 0 has no exposed attributes"});');
+          assert.equal(res.body, 'test({"errors":["Layer 0 has no exposed attributes"]});');
           return null;
         },
         function do_get_attr_1(err)

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -162,7 +162,6 @@ describe('attributes', function() {
         },
         function checkPost(err, res) {
           assert.ifError(err);
-            console.log('rochoa', res.statusCode, res.body);
           assert.equal(res.statusCode, 404, res.statusCode + ': ' + (res.statusCode===200?'...':res.body));
           var parsed = JSON.parse(res.body);
           assert.ok(parsed.errors);

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -701,8 +701,9 @@ describe('multilayer', function() {
           assert.ifError(err);
           assert.equal(res.statusCode, 400, res.statusCode + ': ' + res.body);
           var parsed = JSON.parse(res.body);
-          assert.ok(parsed.error, res.body);
-          var msg = parsed.error;
+          assert.ok(parsed.errors, res.body);
+          assert.equal(parsed.errors.length, 1);
+          var msg = parsed.errors[0];
           assert.ok(msg.match(/Unsupported format json.torque/i), msg);
           return null;
         },

--- a/test/acceptance/multilayer_error_cases.js
+++ b/test/acceptance/multilayer_error_cases.js
@@ -362,7 +362,7 @@ describe('multilayer error cases', function() {
         var mapConfig = testClient.singleLayerMapConfig('select * from test_table', null, null, 'name');
 
         testClient.getGrid(mapConfig, 1, 13, 4011, 3088, defaultErrorExpectedResponse, function(err, res) {
-            assert.deepEqual(JSON.parse(res.body), { error: "Layer '1' not found in layergroup" });
+            assert.deepEqual(JSON.parse(res.body), { errors: ["Layer '1' not found in layergroup"] });
             done();
         });
     });
@@ -390,7 +390,7 @@ describe('multilayer error cases', function() {
           // FIXME: should be 404
           assert.equal(res.statusCode, 400, res.statusCode + ':' + res.body);
           var parsed = JSON.parse(res.body);
-          assert.deepEqual(parsed, {"error": "Invalid or nonexistent map configuration token 'deadbeef'"});
+          assert.deepEqual(parsed, {"errors": ["Invalid or nonexistent map configuration token 'deadbeef'"]});
           return null;
         },
         function finish(err) {
@@ -423,8 +423,7 @@ describe('multilayer error cases', function() {
             },
             function(res) {
                 var parsedBody = JSON.parse(res.body);
-                assert.equal(parsedBody.error, 'SyntaxError');
-                assert.equal(parsedBody.msg, 'Unexpected token {');
+                assert.deepEqual(parsedBody, { errors: ['SyntaxError: Unexpected token {'] });
                 done();
             }
         );

--- a/test/acceptance/regressions.js
+++ b/test/acceptance/regressions.js
@@ -64,7 +64,7 @@ describe('regressions', function() {
                 contentType: 'application/json; charset=utf-8'
             };
             requestTile('/0/0/0.png?testUnexpectedError=1', options, function(err, res) {
-                assert.deepEqual(JSON.parse(res.body),  {"error":"test unexpected error"});
+                assert.deepEqual(JSON.parse(res.body), { "errors": ["test unexpected error"] });
                 finish(done);
             });
         });
@@ -90,8 +90,9 @@ describe('regressions', function() {
 
         testClient.getTile(writeSqlMapConfig, 0, 0, 0, expectedResponse, function(err, res) {
             var parsedBody = JSON.parse(res.body);
-            assert.ok(parsedBody.error);
-            assert.ok(parsedBody.error.match(/read-only transaction/), 'read-only error message expected');
+            assert.ok(parsedBody.errors);
+            assert.equal(parsedBody.errors.length, 1);
+            assert.ok(parsedBody.errors[0].match(/read-only transaction/), 'read-only error message expected');
             done();
         });
     });

--- a/test/acceptance/retina.js
+++ b/test/acceptance/retina.js
@@ -108,7 +108,7 @@ describe('retina support', function() {
             },
             function(res, err) {
                 assert.ok(!err, 'Failed to request 0/0/0' + scaleFactor + '.png tile');
-                assert.deepEqual(JSON.parse(res.body), { error: "Tile with specified resolution not found" } );
+                assert.deepEqual(JSON.parse(res.body), { errors: ["Tile with specified resolution not found"] } );
 
                 done();
             }

--- a/test/acceptance/server.js
+++ b/test/acceptance/server.js
@@ -152,7 +152,7 @@ describe('server', function() {
             }
         };
         testClient.getGridJsonp(mapConfig, 0, 13, 4011, 3088, 'test', expectedResponse, function(err, res) {
-            assert.ok(res.body.match(/"error":/), 'missing error in response: ' + res.body);
+            assert.ok(res.body.match(/"errors":/), 'missing error in response: ' + res.body);
             done();
         });
     });

--- a/test/acceptance/torque.js
+++ b/test/acceptance/torque.js
@@ -214,7 +214,8 @@ describe('torque', function() {
           assert.ifError(err);
           assert.equal(res.statusCode, 400, res.statusCode + ( res.statusCode !== 200 ? (': ' + res.body) : '' ));
           var parsed = JSON.parse(res.body);
-          assert.equal(parsed.error, "No 'mapnik' layers in MapConfig");
+          assert.equal(parsed.errors.length, 1);
+          assert.equal(parsed.errors[0], "No 'mapnik' layers in MapConfig");
           return null;
         },
         function do_get_grid0(err)
@@ -230,7 +231,8 @@ describe('torque', function() {
           assert.ifError(err);
           assert.equal(res.statusCode, 400, res.statusCode + ( res.statusCode !== 200 ? (': ' + res.body) : '' ));
           var parsed = JSON.parse(res.body);
-          assert.equal(parsed.error, "Unsupported format grid.json");
+          assert.equal(parsed.errors.length, 1);
+          assert.equal(parsed.errors[0], "Unsupported format grid.json");
           return null;
         },
         function do_get_torque0(err)


### PR DESCRIPTION
Replaces `error=>String` with `errors=>Array` error responses

Closes #351 