### PR TITLE
Checks the type of torque-specific CSS rules

### DIFF
--- a/lib/windshaft/renderers/torque/factory.js
+++ b/lib/windshaft/renderers/torque/factory.js
@@ -119,6 +119,7 @@ function attrsFromCartoCSS(cartocss, required) {
         this.errors.push(e);
       }
   };
+  var symbolizers = torque_reference.version.latest.layer;
   var root = (carto.Parser(env)).parse(cartocss);
   var definitions = root.toList(env);
   var rules = getMapProperties(definitions, env);
@@ -126,11 +127,31 @@ function attrsFromCartoCSS(cartocss, required) {
   for (var k in attrs_keys) {
     if (rules[k]) {
       attrs[attrs_keys[k]] = rules[k].value.toString();
+      var element = rules[k].value.value[0];
+      var type = symbolizers[k].type;
+      if(!checkValidType(element, type)){
+          throw new Error("Unexpected type for property '" + k + "', expected " + type);
+      }
     } else if ( required && required.indexOf(attrs_keys[k]) !== -1 ) {
         throw new Error("Missing required property '" + k + "' in torque layer CartoCSS");
     }
+
   }
   return attrs;
+}
+
+function checkValidType(e, type){
+    if (type === "number" || type === "float") return typeof e.value === "number";
+    else if (type === "string") return e.value !== "undefined" && typeof e.value === "string";
+    else if (type === "color"){
+        return typeof e.rgb !== "undefined" ||
+            (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
+            (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
+    }
+    else if (type.constructor === Array){
+        return type.indexOf(e.value) > -1 || e.value === "linear";
+    }
+    else return true;
 }
 
 

--- a/lib/windshaft/renderers/torque/factory.js
+++ b/lib/windshaft/renderers/torque/factory.js
@@ -141,7 +141,7 @@ function attrsFromCartoCSS(cartocss, required) {
 }
 
 function checkValidType(e, type){
-    if (["number", "float"].indexOf(e.value)) {
+    if (["number", "float"].indexOf(e.value) > -1) {
       return typeof e.value === "number";
     }
     else if (type === "string"){

--- a/lib/windshaft/renderers/torque/factory.js
+++ b/lib/windshaft/renderers/torque/factory.js
@@ -141,17 +141,24 @@ function attrsFromCartoCSS(cartocss, required) {
 }
 
 function checkValidType(e, type){
-    if (type === "number" || type === "float") return typeof e.value === "number";
-    else if (type === "string") return e.value !== "undefined" && typeof e.value === "string";
-    else if (type === "color"){
-        return typeof e.rgb !== "undefined" ||
-            (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
-            (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
+    if (["number", "float"].indexOf(e.value)) {
+      return typeof e.value === "number";
     }
+    else if (type === "string"){
+      return e.value !== "undefined" && typeof e.value === "string";
+    } 
     else if (type.constructor === Array){
-        return type.indexOf(e.value) > -1 || e.value === "linear";
+      return type.indexOf(e.value) > -1 || e.value === "linear";
     }
-    else return true;
+    else if (type === "color"){
+      return checkValidColor(e);
+    }
+    return true;
+}
+
+function checkValidColor(e){
+  var expectedArguments = { rgb: 3, hsl: 3, rgba: 4, hsla: 4};
+  return typeof e.rgb !== "undefined" || expectedArguments[e.name] === e.args;
 }
 
 


### PR DESCRIPTION
Fixes #150 
Sending a malformed CSS style in the query will make Windshaft respond with a JSON error like the following:

```javascript
{
    errors: [
    "Unexpected type for property '-torque-aggregation-function', expected string"
    ]
}
```

@rochoa what do you think?
cc @javisantana 