### PR TITLE
Improve renderers draining from renderer cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,17 @@
 # Version 0.49.1
 2015-mm-dd
 
+Enhancements:
+ - Implements close mechanism for torque renderer to free canvas' images
+ - Base adaptor exposes and calls renderers' close if available
+ - Blend renderer calls close on all renderers
+
 Bug fixes:
  - Honor RenderCache ttl option
 
 Announcements:
  - Do not report png cache size on renderers
+ - Uses [cartodb/node-canvas@1.2.7-cdb1](https://github.com/CartoDB/node-canvas/releases/tag/1.2.7-cdb1)
 
 
 # Version 0.49.0

--- a/lib/windshaft/renderers/base_adaptor.js
+++ b/lib/windshaft/renderers/base_adaptor.js
@@ -27,9 +27,9 @@ function BaseAdaptor(renderer, format, onTileErrorStrategy) {
     this.get = function() {
         return renderer;
     };
-    this.close = function() {
+    this.close = function(callback) {
         if (renderer.close) {
-            renderer.close();
+            renderer.close(callback);
         }
     };
     this.getStats = function() {

--- a/lib/windshaft/renderers/base_adaptor.js
+++ b/lib/windshaft/renderers/base_adaptor.js
@@ -27,7 +27,11 @@ function BaseAdaptor(renderer, format, onTileErrorStrategy) {
     this.get = function() {
         return renderer;
     };
-    this.close = function() {};
+    this.close = function() {
+        if (renderer.close) {
+            renderer.close();
+        }
+    };
     this.getStats = function() {
         return (renderer.getStats && renderer.getStats()) || {
             pool: {

--- a/lib/windshaft/renderers/blend/renderer.js
+++ b/lib/windshaft/renderers/blend/renderer.js
@@ -105,3 +105,9 @@ Renderer.prototype.getStats = function() {
         }
     );
 };
+
+Renderer.prototype.close = function() {
+    this.renderers.forEach(function(renderer) {
+        renderer.close();
+    });
+};

--- a/lib/windshaft/renderers/blend/renderer.js
+++ b/lib/windshaft/renderers/blend/renderer.js
@@ -106,8 +106,8 @@ Renderer.prototype.getStats = function() {
     );
 };
 
-Renderer.prototype.close = function() {
+Renderer.prototype.close = function(callback) {
     this.renderers.forEach(function(renderer) {
-        renderer.close();
+        renderer.close(callback);
     });
 };

--- a/lib/windshaft/renderers/http/fallback_renderer.js
+++ b/lib/windshaft/renderers/http/fallback_renderer.js
@@ -76,3 +76,7 @@ function getFsTile(fallbackImagePath, callback) {
         return callback(null, buffer);
     });
 }
+
+Renderer.prototype.close = function() {
+    this.cachedTile = null;
+};

--- a/lib/windshaft/renderers/plain/renderer.js
+++ b/lib/windshaft/renderers/plain/renderer.js
@@ -63,3 +63,7 @@ Renderer.prototype.getTile = function(z, x, y, callback) {
 Renderer.prototype.getMetadata = function(callback) {
     return callback(null, {});
 };
+
+Renderer.prototype.close = function() {
+    this.cachedTile = null;
+};

--- a/lib/windshaft/renderers/torque/png_renderer.js
+++ b/lib/windshaft/renderers/torque/png_renderer.js
@@ -14,6 +14,9 @@ function PngRenderer(layer, sql, attrs) {
 
     Renderer.apply(this, [layer, sql, attrs, rendererOptions]);
 
+    this.canvasImages = [];
+    var self = this;
+
     this.provider = new torque.providers.windshaft(_.extend(
         {
             no_fetch_map: true,
@@ -28,6 +31,9 @@ function PngRenderer(layer, sql, attrs) {
         // It should not request the same file as many times as setImageSrc is invoked
         // Right now it will be called: (# different marker-files) * (# calls to renderer.Point.renderTile) times
         setImageSrc: function(img, url, callback) {
+
+            self.canvasImages.push(img);
+
             var requestOpts = {
                 url: url,
                 method: 'GET',
@@ -98,4 +104,15 @@ PngRenderer.prototype.getTile = function(z, x, y, callback) {
             callback(err, null, {});
         }
     });
+};
+
+PngRenderer.prototype.close = function() {
+    this.canvasImages.forEach(function(img) {
+        // unbind handlers so they don't callback anymore
+        img.onerror = null;
+        img.onload = null;
+        // trick to avoid leak of image buffer
+        img.src = null;
+    });
+    this.canvasImages = [];
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "tilelive": "~4.5.3",
         "tilelive-mapnik": "https://github.com/CartoDB/tilelive-mapnik/tarball/0.6.x-cdb1",
         "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb2",
-        "canvas": "https://github.com/CartoDB/node-canvas/tarball/cdb",
+        "canvas": "https://github.com/CartoDB/node-canvas/tarball/1.2.7-cdb1",
         "semver": "~1.1.4",
         "redis-mpool": "~0.4.0",
         "carto": "https://github.com/CartoDB/carto/tarball/0.15.1-cdb1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "tilelive": "~4.5.3",
         "tilelive-mapnik": "https://github.com/CartoDB/tilelive-mapnik/tarball/0.6.x-cdb1",
         "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb2",
-        "canvas": "1.2.1",
+        "canvas": "https://github.com/CartoDB/node-canvas/tarball/cdb",
         "semver": "~1.1.4",
         "redis-mpool": "~0.4.0",
         "carto": "https://github.com/CartoDB/carto/tarball/0.15.1-cdb1",


### PR DESCRIPTION
 - Uses [cartodb/node-canvas@1.2.7-cdb1](https://github.com/CartoDB/node-canvas/releases/tag/1.2.7-cdb1)
 - Implements close mechanism for torque renderer to free canvas' images
 - Base adaptor exposes and calls renderers' close if available
 - Blend renderer calls close on all renderers