### PR TITLE
RendererCache invoke gc 1 out of 10 times it runs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-# Version 0.50.1
+# Version 0.51.0
 2015-mm-dd
+
+New features:
+ - When gc extension is enabled with `--expose_gc` flag, RendererCache will invoke gc 1 out of 10 times it runs.
 
 
 # Version 0.50.0

--- a/lib/windshaft/renderers/render_cache.js
+++ b/lib/windshaft/renderers/render_cache.js
@@ -14,18 +14,34 @@ module.exports = function(options, map_store, rendererFactory) {
     var me = {
         serial: 0,
         renderers: {},
+        gcRun: 0,
         timeout: options.timeout || options.ttl || 60000
+    };
+
+    me.shouldRunGc = function() {
+        if (++me.gcRun % 10 === 0) {
+            me.gcRun = 0;
+            return true;
+        }
+        return false;
     };
 
     me.lastCacheClearRun = Date.now();
     me.cacheClearInterval = setInterval( function() {
-      var now = Date.now();
-      _.each(me.renderers, function(cache_entry, key) {
-          if ( cache_entry.timeSinceLastAccess(now) > me.timeout ) {
-            me.del(key);
-          }
-      });
-      me.lastCacheClearRun = now;
+        var now = Date.now();
+        _.each(me.renderers, function(cache_entry, key) {
+            if ( cache_entry.timeSinceLastAccess(now) > me.timeout ) {
+                me.del(key);
+            }
+        });
+        me.lastCacheClearRun = now;
+
+        // node should run with `--expose_gc` flag to enable gc extension
+        if (me.shouldRunGc() && global.gc) {
+            var start = Date.now();
+            global.gc();
+            global.statsClient.timing('windshaft.rendercache.gc', Date.now() - start);
+        }
     }, me.timeout );
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "0.50.1",
+    "version": "0.51.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [


### PR DESCRIPTION
That behaviour applies only when gc extension is enabled with `--expose_gc` flag.