### PR TITLE
Adds support for substitution tokens in Torque

### DIFF
--- a/lib/windshaft/renderers/torque/factory.js
+++ b/lib/windshaft/renderers/torque/factory.js
@@ -14,6 +14,8 @@ var PSQLAdaptor = require('./psql_adaptor');
 var PngRenderer = require('./png_renderer');
 var BaseAdaptor = require('../base_adaptor');
 
+var SubstitutionTokens = require('./substitution_tokens');
+
 /// API: initializes the renderer, it should be called once
 //
 /// @param options initialization options.
@@ -251,6 +253,13 @@ function fetchMapConfigAttributes(sql, mapConfig, dbParams, layer_id, callback) 
 
 function fetchLayerAttributes(sql, layer_sql, attrs, callback) {
   var is_time;
+
+  layer_sql = SubstitutionTokens.replace(layer_sql, {
+      bbox: 'ST_MakeEnvelope(0,0,0,0)',
+      scale_denominator: '0',
+      pixel_width: '1',
+      pixel_height: '1'
+  });
 
   step(
 

--- a/lib/windshaft/renderers/torque/renderer.js
+++ b/lib/windshaft/renderers/torque/renderer.js
@@ -1,6 +1,7 @@
 var format = require('../../utils/format');
 var Timer = require('../../stats/timer');
 var debug = require('debug')('windshaft:renderer:torque');
+var SubstitutionTokens = require('./substitution_tokens');
 
 /// CLASS: torque Renderer
 //
@@ -135,16 +136,26 @@ Renderer.prototype = {
             ") cte, par  " +
             "GROUP BY x__uint8, y__uint8; ";
 
-        var query = format(tile_sql, attrs, {
+        var extent = cdb_XYZ_Extent(coord.x, coord.y, zoom);
+        var xyz_resolution = cdb_XYZ_Resolution(zoom);
+
+        layer_sql = SubstitutionTokens.replace(layer_sql, {
+            bbox: format('ST_MakeEnvelope({xmin},{ymin},{xmax},{ymax},{srid})', { srid: geom_column_srid }, extent),
+            // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
+            scale_denominator: xyz_resolution / 0.00028,
+            pixel_width: xyz_resolution,
+            pixel_height: xyz_resolution
+        });
+
+        var query = format(tile_sql, {_sql: layer_sql}, attrs, {
             zoom: zoom,
             x: coord.x,
             y: coord.y,
             column_conv: column_conv,
-            _sql: layer_sql,
-            xyz_resolution: cdb_XYZ_Resolution(zoom),
+            xyz_resolution: xyz_resolution,
             srid: geom_column_srid,
             gcol: geom_column
-        }, cdb_XYZ_Extent(coord.x, coord.y, zoom));
+        }, extent);
 
         var timer = new Timer();
         timer.start('query');

--- a/lib/windshaft/renderers/torque/substitution_tokens.js
+++ b/lib/windshaft/renderers/torque/substitution_tokens.js
@@ -1,0 +1,19 @@
+var SUBSTITUTION_TOKENS = {
+    bbox: /!bbox!/g,
+    scale_denominator: /!scale_denominator!/g,
+    pixel_width: /!pixel_width!/g,
+    pixel_height: /!pixel_height!/g
+};
+
+var SubstitutionTokens = {
+    replace: function(sql, replaceValues) {
+        Object.keys(replaceValues).forEach(function(token) {
+            if (SUBSTITUTION_TOKENS[token]) {
+                sql = sql.replace(SUBSTITUTION_TOKENS[token], replaceValues[token]);
+            }
+        });
+        return sql;
+    }
+};
+
+module.exports = SubstitutionTokens;

--- a/test/unit/renderers/torque_substitutions_tokens.js
+++ b/test/unit/renderers/torque_substitutions_tokens.js
@@ -1,0 +1,21 @@
+require('../../support/test_helper');
+
+var assert = require('assert');
+var SubstitutionTokens = require('../../../lib/windshaft/renderers/torque/substitution_tokens');
+
+describe('Torque substitution tokens', function() {
+
+    var tokens = ['bbox', 'pixel_width', 'pixel_height', 'scale_denominator'];
+    tokens.forEach(function(token) {
+        it('replaces token: ' + token, function() {
+            var replaceValues = {};
+            replaceValues[token] = 'wadus';
+            assert.equal(SubstitutionTokens.replace('!' + token + '!', replaceValues), replaceValues[token]);
+        });
+    });
+
+    it('should not replace unsupported tokens', function() {
+        var replaceValues = { unsupported: 'wadus' };
+        assert.equal(SubstitutionTokens.replace('!unsupported!', replaceValues), '!unsupported!');
+    });
+});


### PR DESCRIPTION
Supported substitution tokens are:
 - !bbox! spatial filter applied in the tile
 - !pixel_width! width of a pixel in geographical units
 - !pixel_height! height of a pixel in geographical units
 - !scale_denominator! display pixel size

They have the same semantics than the ones in Mapnik's PostGIS plugin. For
more information about them check:
https://github.com/mapnik/mapnik/wiki/PostGIS#advanced-usage

Check https://github.com/mapnik/mapnik/wiki/ScaleAndPpi for more information
about scale_denominator.