### PR TITLE
Cuts geojson geometries into tiles to avoid a lot of redundancy in client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_install:
  - sudo add-apt-repository -y ppa:cartodb/cairo
  - sudo apt-get update
- - sudo apt-get install -y pkg-config libcairo2-dev libjpeg8-dev libgif-devs
+ - sudo apt-get install -y pkg-config libcairo2-dev libjpeg8-dev libgif-dev
  - sudo add-apt-repository -y ppa:fkrull/deadsnakes
  - sudo apt-get update
  - sudo apt-get install -y python2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ env:
 before_install:
  - sudo add-apt-repository -y ppa:cartodb/cairo
  - sudo apt-get update
- - sudo apt-get install -y pkg-config libcairo2-dev libjpeg8-dev libgif-dev
- - sudo add-apt-repository -y ppa:fkrull/deadsnakes
- - sudo apt-get update
- - sudo apt-get install -y python2.7
+ - sudo apt-get install -y pkg-config libcairo2-dev libjpeg8-dev libgif-dev postgresql-plpython-9.3
 
 language: node_js
 node_js:

--- a/lib/windshaft/renderers/mapnik/geojson_template.sql
+++ b/lib/windshaft/renderers/mapnik/geojson_template.sql
@@ -1,6 +1,6 @@
 SELECT row_to_json(featcoll) as geojson FROM
   (SELECT 'FeatureCollection' AS TYPE, array_to_json(array_agg(feat)) AS features FROM
-    (SELECT 'Feature' AS TYPE, ST_AsGeoJSON(tbl.<%= geomColumn %>)::json AS geometry, <% if (!columns || columns.length === 0) {%> '{}'::json <% } else {%> row_to_json(
+    (SELECT 'Feature' AS TYPE, ST_AsGeoJSON(ST_Intersection(tbl.<%= geomColumn %>, CDB_XYZ_Extent(<%= coord.x %>, <%= coord.y %>, <%= zoom %>)))::json AS geometry, <% if (!columns || columns.length === 0) {%> '{}'::json <% } else {%> row_to_json(
       (SELECT l FROM
         (SELECT <% _.each(columns, function(col, i) { %> <%= col %> <% if (i < (columns.length - 1)) {%>, <% } %> <% }); %>) AS l
       )

--- a/lib/windshaft/renderers/mapnik/geojson_template.sql
+++ b/lib/windshaft/renderers/mapnik/geojson_template.sql
@@ -1,6 +1,6 @@
 SELECT row_to_json(featcoll) as geojson FROM
   (SELECT 'FeatureCollection' AS TYPE, array_to_json(array_agg(feat)) AS features FROM
-    (SELECT 'Feature' AS TYPE, ST_AsGeoJSON(ST_Intersection(tbl.<%= geomColumn %>, CDB_XYZ_Extent(<%= coord.x %>, <%= coord.y %>, <%= zoom %>)))::json AS geometry, <% if (!columns || columns.length === 0) {%> '{}'::json <% } else {%> row_to_json(
+    (SELECT 'Feature' AS TYPE, ST_AsGeoJSON(ST_Intersection(tbl.<%= geomColumn %>, st_expand(CDB_XYZ_Extent(<%= coord.x %>, <%= coord.y %>, <%= zoom %>), 10000)))::json AS geometry, <% if (!columns || columns.length === 0) {%> '{}'::json <% } else {%> row_to_json(
       (SELECT l FROM
         (SELECT <% _.each(columns, function(col, i) { %> <%= col %> <% if (i < (columns.length - 1)) {%>, <% } %> <% }); %>) AS l
       )


### PR DESCRIPTION
@dgaubert let's integrate this in the mapconfig+geojson branch so that we reduce the stress of the renderer right away? It's still missing things like simplifying features and so on but this change reliefs the renderer from a massive burden of redundant features.

cc @rochoa 