### PR TITLE
Upgrade node-mapnik to 1.4.15-cdb7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Version 1.19.1
 2016-mm-dd
 
+Announcements:
+ - Upgrades node-mapnik to 1.4.15-cdb7
 
 # Version 1.19.0
 2016-04-28

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "debug": "~2.2.0",
         "dot": "~1.0.2",
         "grainstore": "1.1.1",
-        "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb6",
+        "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb7",
         "queue-async": "~1.0.7",
         "redis-mpool": "~0.4.0",
         "request": "2.62.0",


### PR DESCRIPTION
I just realized https://github.com/cartodb/abaculus also depends on node mapnik. I may need some help to polish the release preparation @rochoa 