### PR TITLE
Upgrade mapnik to 1.4.15-cdb8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ New features:
 
 Announcements:
  - Upgrades carto to 0.15.1-cdb2
+ - Upgrades mapnik to [cartodb/node-mapnik@1.4.15-cdb8](https://github.com/CartoDB/node-mapnik/releases/tag/1.4.15-cdb8)
 
 
 # Version 1.18.0

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
         "Raul Ochoa <rochoa@cartodb.com>"
     ],
     "dependencies": {
-        "abaculus": "https://github.com/CartoDB/abaculus/tarball/1.1.0-cdb4",
+        "abaculus": "https://github.com/CartoDB/abaculus/tarball/1.1.0-cdb5",
         "canvas": "https://github.com/CartoDB/node-canvas/tarball/1.2.7-cdb1",
         "carto": "https://github.com/CartoDB/carto/tarball/0.15.1-cdb2",
         "cartodb-psql": "~0.6.1",
         "debug": "~2.2.0",
         "dot": "~1.0.2",
         "grainstore": "1.1.1",
-        "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb6",
+        "mapnik": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb8",
         "queue-async": "~1.0.7",
         "redis-mpool": "~0.4.0",
         "request": "2.62.0",
@@ -35,8 +35,8 @@
         "sphericalmercator": "1.0.3",
         "step": "~0.0.6",
         "tilelive": "~4.5.3",
-        "tilelive-bridge": "https://github.com/CartoDB/tilelive-bridge/tarball/1.3.0-cdb4",
-        "tilelive-mapnik": "https://github.com/CartoDB/tilelive-mapnik/tarball/0.6.15-cdb5",
+        "tilelive-bridge": "https://github.com/CartoDB/tilelive-bridge/tarball/1.3.0-cdb5",
+        "tilelive-mapnik": "https://github.com/CartoDB/tilelive-mapnik/tarball/0.6.15-cdb7",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },


### PR DESCRIPTION
Stuff that depends on node mapnik:
- windshaft
  - [abaculus](https://github.com/CartoDB/abaculus/releases/1.1.0-cdb5)
  - [tilelive-bridge](https://github.com/CartoDB/tilelive-bridge/releases/1.3.0-cdb5)
      - [mapnik-pool](https://github.com/CartoDB/mapnik-pool/releases/0.1.1-cdb5)
  - [tilelive-mapnik](https://github.com/CartoDB/tilelive-mapnik/release/0.6.15-cdb7)

I'd like to merge this, close and tag this version `1.19.1` (and open a new stub one) and proceed with the changes and deploy of windshaft-cartodb. Can I proceed, @rochoa ?