### PR TITLE
Do not enforce a dbuser in connection

### DIFF
--- a/test/integration/static_maps.js
+++ b/test/integration/static_maps.js
@@ -98,7 +98,6 @@ describe('static_maps', function() {
         var defaultParams = {
             dbname: 'windshaft_test',
             token: crypto.createHash('md5').update(JSON.stringify(layergroup)).digest('hex'),
-            dbuser: 'postgres',
             format: 'png',
             layer: 'all'
         };


### PR DESCRIPTION
Connection params should be driven by env configuration

Fixes 8 tests over 14 failing as reported in #495