### PR TITLE
Use "affected_table" in mapnik layer option when available

### DIFF
--- a/lib/windshaft/metadata/mapnik-layer-metadata.js
+++ b/lib/windshaft/metadata/mapnik-layer-metadata.js
@@ -33,6 +33,12 @@ MapnikLayerMetadata.prototype.getMetadata = function (mapConfig, layer, layerId,
             assert.ifError(err);
 
             var next = this;
+
+            if (layer.options.affected_tables) {
+                next(null, pg, layer.options.affected_tables);
+                return;
+            }
+
             var query = queryUtils.extractTableNames(layer.options.sql);
 
             pg.query(query, function (err, result) {


### PR DESCRIPTION
.. instead of extracting table names from the query (which is known
to not always yeld the correct result, especially when the query
uses functions to fetch data)

Also helps reducing dependency on cartodb-postgresql for deploys
with controlled MapConfig editing (see #503)

NOTE: this was tested on a live system, but the PR does not contain an automated test