### PR TITLE
Version 2.7.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-# Version 2.6.6
-2016-mm-dd
+# Version 2.7.0
+2017-02-20
+
+Announcements:
+ - Upgrades cartodb-psql to [0.7.1](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.7.1).
 
 
 # Version 2.6.5

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "abaculus": "cartodb/abaculus#1.1.0-cdb7",
         "canvas": "cartodb/node-canvas#1.2.7-cdb1",
         "carto": "cartodb/carto#0.15.1-cdb2",
-        "cartodb-psql": "~0.6.1",
+        "cartodb-psql": "~0.7.1",
         "debug": "~2.2.0",
         "dot": "~1.0.2",
         "grainstore": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "2.6.6",
+    "version": "2.7.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [


### PR DESCRIPTION
- Update cartodb-psql to version [0.7.1](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.7.1)