### PR TITLE
[LIMITS] Response timeout limit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# Version 3.3.0
+2017-mm-dd
+
+Announcements:
+ - Upgrade tilelive-bridge to [2.3.1-cdb4](https://github.com/CartoDB/tilelive-bridge/releases/tag/2.3.1-cdb4).
+ - Upgrade tilelive-mapnik to [0.6.18-cdb3](https://github.com/CartoDB/tilelive-mapnik/releases/tag/0.6.18-cdb2).
+ - Upgrade cartodb-psql to [0.9.0](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.9.0).
+
+
 # Version 3.2.2
 2017-07-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "abaculus": "cartodb/abaculus#2.0.3-cdb1",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
-        "cartodb-psql": "0.8.0",
+        "cartodb-psql": "0.9.0",
         "debug": "~2.2.0",
         "dot": "~1.0.2",
         "grainstore": "~1.6.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-bridge": "cartodb/tilelive-bridge#query-timeout",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#custom-timeout",
+        "tilelive-bridge": "cartodb/tilelive-bridge#2.3.1-cdb4",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb3",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-bridge": "cartodb/tilelive-bridge#2.3.1-cdb3",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb2",
+        "tilelive-bridge": "cartodb/tilelive-bridge#query-timeout",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#custom-timeout",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },


### PR DESCRIPTION
Fixes #556 

Upgrades:
  - [x] tilelive-mapnik to 0.6.18-cdb3
  - [x] tilelive-bridge to 2.3.1-cdb4
  - [x] cartodb-psql to 0.9.0
