### PR TITLE
Enable docker debugging by exposing Node debug port to host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ RUN apt-get -y purge $DEV_DEPENDENCIES
 RUN apt-get -y autoremove
 
 WORKDIR /srv
+EXPOSE 5858
 CMD /etc/init.d/postgresql start && node -v && export NPROCS=1 && export JOBS=1 && export CXX=g++-4.9 && npm install && export PGUSER=postgres && npm test

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "test": "make test-all",
         "docker-install": "sudo apt install docker.io && sudo usermod -aG docker $(whoami)",
         "docker-pull": "docker pull cartoimages/windshaft-testing",
-        "docker-test": "docker run -v `pwd`:/srv cartoimages/windshaft-testing",
+        "docker-test": "docker run -p 127.0.0.1:5858:5858 -v `pwd`:/srv cartoimages/windshaft-testing",
         "docker-build": "docker build -t cartoimages/windshaft-testing .",
         "docker-publish": "docker push cartoimages/windshaft-testing"
     },


### PR DESCRIPTION
Expose node debug port (5858) to host to allow easier debugging