### PR TITLE
Fix PostGIS MVT query

### DIFF
--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -43,7 +43,7 @@ Renderer.prototype = {
             var subQuery = SubstitutionTokens.replace(layer.options.sql, {
                 bbox: `CDB_XYZ_Extent(${x},${y},${z})`,
                 // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
-                scale_denominator: `(cdb_XYZ_Resolution(${z}) / 0.00028)`,
+                scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric / 0.00028)`,
                 pixel_width: `cdb_XYZ_Resolution(${z})`,
                 pixel_height: `cdb_XYZ_Resolution(${z})`,
                 var_zoom: z,


### PR DESCRIPTION
Fix scale denominator token substitution to take care of `cdb_XYZ_Resolution` return type 