### PR TITLE
MVT buffersize fix

### DIFF
--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -65,7 +65,9 @@ PgMvtFactory.prototype = {
 
         _.extend(dbParams, mapConfig.getLayerDatasource(layer));
         const psql = new PSQL(dbParams, this.options.dbPoolParams);
-
-        return callback(null, new Renderer(layers, psql, {}, layer));
+        if (Number.isFinite(mapConfig.getBufferSize('mvt'))) {
+            this.options.bufferSize = mapConfig.getBufferSize('mvt');
+        }
+        return callback(null, new Renderer(layers, psql, {}, this.options));
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -33,9 +33,9 @@ Renderer.prototype = {
         const subqueries = this.layers.map(layer => {
 
             // Geometry column
-            const pixelsBufferSize = Math.round(this.buffer_size * this.mvt_extent / this.tile_size);
+            const subpixelBufferSize = Math.round(this.buffer_size * this.mvt_extent / this.tile_size);
             const geomColumn = `ST_AsMVTGeom(
-                the_geom_webmercator, CDB_XYZ_Extent(${x},${y},${z}), ${this.mvt_extent}, ${pixelsBufferSize}, true
+                the_geom_webmercator, CDB_XYZ_Extent(${x},${y},${z}), ${this.mvt_extent}, ${subpixelBufferSize}, true
             )`;
 
             var columns = [geomColumn].concat(LayerColumns.getColumns(layer.options));
@@ -43,9 +43,9 @@ Renderer.prototype = {
             var subQuery = SubstitutionTokens.replace(layer.options.sql, {
                 bbox: `CDB_XYZ_Extent(${x},${y},${z})`,
                 // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
-                scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric / 0.00028)`,
-                pixel_width: `cdb_XYZ_Resolution(${z})`,
-                pixel_height: `cdb_XYZ_Resolution(${z})`,
+                scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric *${256 / this.tile_size / 0.00028})`,
+                pixel_width: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
+                pixel_height: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
                 var_zoom: z,
                 var_x: x,
                 var_y: y
@@ -54,8 +54,9 @@ Renderer.prototype = {
             return `(select st_asmvt(geom, '${layer.id}') FROM (
                 SELECT ${columns.join(',')}
                 FROM (${subQuery}) AS cdbq
-                WHERE the_geom_webmercator && CDB_XYZ_Extent(${x},${y},${z}))
-                AS geom
+                WHERE the_geom_webmercator && ST_Expand(CDB_XYZ_Extent(${x},${y},${z}),
+                    cdb_XYZ_Resolution(${z})*${Math.round(256 * this.buffer_size / this.tile_size)})
+                )AS geom
             )`;
         });
         var query = `SELECT (${subqueries.join(' || ')}) AS st_asmvt`;


### PR DESCRIPTION
This PR fix 2 buffersize problems:

- It fixes the SQL query to expand the bounding box by using the buffersize
- It fixes the pg-mvt factory to get the mapConfig buffersize value

Additionally, it fixes the query substitution for tiles with sizes different than 256 pixels.