### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,76 @@
 FROM ubuntu:xenial
 
 # Add external repos
-RUN apt-get -y update
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get -y update
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y \
+      curl \
+      software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && curl -sL https://deb.nodesource.com/setup_6.x | bash
 
-#Use UTF8 to avoid encoding problems with pgsql
-RUN apt-get -y install locales
+# Install dependencies and PostGIS 2.4 from sources
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y \
+      g++-4.9 \
+      gcc-4.9 \
+      git \
+      libcairo2-dev \
+      libgdal-dev \
+      libgdal1i \
+      libgeos-dev \
+      libgif-dev \
+      libjpeg8-dev \
+      libjson-c-dev \
+      libpango1.0-dev \
+      libpixman-1-dev \
+      libproj-dev \
+      libprotobuf-c-dev \
+      libxml2-dev \
+      locales \
+      make \
+      nodejs \
+      pkg-config \
+      postgresql-9.5 \
+      postgresql-plpython-9.5 \
+      postgresql-server-dev-9.5 \
+      protobuf-c-compiler \
+      redis-server \
+      wget \
+    && wget http://download.osgeo.org/postgis/source/postgis-2.4.0.tar.gz \
+    && tar xvfz postgis-2.4.0.tar.gz \
+    && cd postgis-2.4.0 \
+    && ./configure \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf postgis-2.4.0 \
+    && apt-get purge -y wget protobuf-c-compiler \
+    && apt-get autoremove -y
+
+# Use UTF8 to avoid encoding problems with pgsql
 ENV LANG C.UTF-8
-RUN locale-gen en_US.UTF-8
-RUN update-locale LANG=en_US.UTF-8
-
-#Add 6.X node ppa
-RUN apt-get -y install curl
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash
-
-RUN apt-get -y install make libpixman-1-dev pkg-config postgresql-9.5 libcairo2-dev  libjpeg8-dev libgif-dev libpango1.0-dev libgdal1i libgeos-dev libxml2-dev libgdal-dev libproj-dev postgresql-server-dev-9.5 redis-server nodejs gcc-4.9 g++-4.9 libprotobuf-c-dev git postgresql-plpython-9.5 libjson-c-dev wget protobuf-c-compiler
-
-# Install PostGIS 2.4 from sources
-RUN wget http://download.osgeo.org/postgis/source/postgis-2.4.0.tar.gz && tar xvfz postgis-2.4.0.tar.gz && cd postgis-2.4.0 && ./configure && make && make install && cd .. && rm -rf postgis-2.4.0
+RUN set -ex \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8
 
 # Configure PostgreSQL
-RUN echo "local     all       all                     trust" > /etc/postgresql/9.5/main/pg_hba.conf
-RUN echo "host      all       all       0.0.0.0/0     trust" >> /etc/postgresql/9.5/main/pg_hba.conf
-RUN echo "host      all       all       ::1/128       trust" >> /etc/postgresql/9.5/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/9.5/main/postgresql.conf
-
-# Clean
-RUN apt-get -y remove wget protobuf-c-compiler
-RUN apt-get -y autoremove
+RUN set -ex \
+    && echo "listen_addresses='*'" >> /etc/postgresql/9.5/main/postgresql.conf \
+    && echo "local     all       all                     trust" >  /etc/postgresql/9.5/main/pg_hba.conf \
+    && echo "host      all       all       0.0.0.0/0     trust" >> /etc/postgresql/9.5/main/pg_hba.conf \ 
+    && echo "host      all       all       ::1/128       trust" >> /etc/postgresql/9.5/main/pg_hba.conf
 
 WORKDIR /srv
 EXPOSE 5858
-CMD /etc/init.d/postgresql start && node -v && export NPROCS=1 && export JOBS=1 && export CXX=g++-4.9 && npm install && export PGUSER=postgres && npm test
+
+CMD set -ex \
+    && /etc/init.d/postgresql start \
+    && node -v \
+    && export NPROCS=1 \
+    && export JOBS=1 \
+    && export CXX=g++-4.9 \
+    && npm install \
+    && export PGUSER=postgres \
+    && npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM ubuntu:xenial
 
+# Use UTF8 to avoid encoding problems with pgsql
+ENV LANG C.UTF-8
+
 # Add external repos
 RUN set -ex \
     && apt-get update \
     && apt-get install -y \
       curl \
       software-properties-common \
+      locales \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-    && curl -sL https://deb.nodesource.com/setup_6.x | bash
+    && curl -sL https://deb.nodesource.com/setup_6.x | bash \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8
 
 # Install dependencies and PostGIS 2.4 from sources
 RUN set -ex \
@@ -28,7 +34,6 @@ RUN set -ex \
       libproj-dev \
       libprotobuf-c-dev \
       libxml2-dev \
-      locales \
       make \
       nodejs \
       pkg-config \
@@ -49,17 +54,11 @@ RUN set -ex \
     && apt-get purge -y wget protobuf-c-compiler \
     && apt-get autoremove -y
 
-# Use UTF8 to avoid encoding problems with pgsql
-ENV LANG C.UTF-8
-RUN set -ex \
-    && locale-gen en_US.UTF-8 \
-    && update-locale LANG=en_US.UTF-8
-
 # Configure PostgreSQL
 RUN set -ex \
     && echo "listen_addresses='*'" >> /etc/postgresql/9.5/main/postgresql.conf \
     && echo "local     all       all                     trust" >  /etc/postgresql/9.5/main/pg_hba.conf \
-    && echo "host      all       all       0.0.0.0/0     trust" >> /etc/postgresql/9.5/main/pg_hba.conf \ 
+    && echo "host      all       all       0.0.0.0/0     trust" >> /etc/postgresql/9.5/main/pg_hba.conf \
     && echo "host      all       all       ::1/128       trust" >> /etc/postgresql/9.5/main/pg_hba.conf
 
 WORKDIR /srv


### PR DESCRIPTION
Optimize the Dockerfile by moving `apt-get update` and `apt-get install` into the same command (to preserve image state), combining commands to reduce layers being created, and reducing both the time and size required to build and store the resulting image layers. I implemented everything I was familiar with from [the best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/), but I'm sure there's always room for improvement.

This removes 13 redundant layers which were taking up time and space. I'm using `set -ex` for maximum verbosity, but please let me know if you'd prefer another style. Thanks for your work on Windshaft!