### PR TITLE
Force png tile generation for static maps

### DIFF
--- a/lib/windshaft/backends/preview.js
+++ b/lib/windshaft/backends/preview.js
@@ -46,6 +46,8 @@ PreviewBackend.prototype.getImage = function(mapConfigProvider, format, width, h
 
     step(
         function() {
+            // Force tile format to be PNG which is the only we support
+            mapConfigProvider.params.format = 'png';
             self._rendererCache.getRenderer(mapConfigProvider, this);
         },
         function getImage(err, r) {


### PR DESCRIPTION
If the user tries to generate a static map requesting JPG it will fail
because is going to try to generate the tiles using JPG as format which
is not supported by now

So we now force the tiles for be generated as PNG and we ask abaculous
to generate the final image as a JPEG