### PR TITLE
Upgrade mapnik 3.6.2 carto.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ before_install:
   - docker pull cartoimages/windshaft-testing
 
 script:
-  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-testing
+  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-testing bash docker-test.sh
 
 language: generic

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,22 @@
-# Version 4.2.1
-2018-mm-dd
+# Version 4.3.0
+2018-01-11
 
 Bug fixes:
-- Fix broken torque tests for PG9.6+
+ - Fix broken torque tests for PG9.6+
+
+New features:
+ - Now mapnik has support for fine-grained metrics.
+ - Variables can be passed for later substitution in postgis datasource.
+
+Announcements:
+ - Upgrade mapnik to @carto/mapnik 3.6.2-carto.1, which uses carto lib mapnik v3.0.15.2 underneath. See https://github.com/CartoDB/mapnik/blob/v3.0.15-carto/CHANGELOG.carto.md and https://github.com/CartoDB/mapnik/blob/v3.0.15-carto/CHANGELOG.carto.md
+ - Upgrade tilelive-bridge to @carto/tilelive-bridge 2.5.1-cdb1. See https://github.com/CartoDB/tilelive-bridge/blob/cdb-2.x/CHANGELOG.carto.md
+ - Upgrade tilelive-mapnik to 0.6.18-cdb4
+ - Upgrade abaculus to 2.0.3-cdb2
+ - Upgrade grainstore to 1.8.1
+ - Use yarn instead of npm
+ - Use the script docker-test.sh for travis builds
+
 
 # Version 4.2.0
 2018-01-02

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ More examples built on top of Windshaft can be found in [CARTO's gallery](http:/
 Dependencies
 ------------
 * Node >= 6.9
-* npm >= 3.10
+* yarn >= 0.27.5
 * Mapnik 3.x. See [Installing Mapnik](#installing-mapnik).
 * PostgreSQL > 8.3.x, PostGIS > 1.5.x
 * Redis > 2.2.x
@@ -50,7 +50,7 @@ sudo apt-get install -y build-essential checkinstall pkg-config libcairo2-dev li
 Install
 -------
 ```
-npm install [windshaft]
+yarn install [windshaft]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Tests
 -----
 
 Windshaft has a unit and acceptance test suite.
-To execute them, run `npm test`.
+To execute them, run `yarn test`.
 
 You'll need to be sure your PGUSER (or your libpq default) is
 set to a "superuser" PostgreSQL account, for example:
 
 ```shell
-PGUSER=postgres npm test
+PGUSER=postgres yarn test
 ```
 
 

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,10 +1,11 @@
 /etc/init.d/postgresql start
 node -v
 npm -v
+npm install -g yarn@0.27.5
 export NPROCS=1
 export JOBS=1
 export CXX=g++-4.9
-npm install
+yarn
 export PGUSER=postgres
 export POSTGIS_VERSION=2.4
 npm test

--- a/examples/http/server.js
+++ b/examples/http/server.js
@@ -2,7 +2,7 @@ var debug = require('debug')('windshaft:server');
 var express = require('express');
 var RedisPool = require('redis-mpool');
 var _ = require('underscore');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 
 var windshaft = require('../../lib/windshaft');
 

--- a/lib/windshaft/index.js
+++ b/lib/windshaft/index.js
@@ -1,6 +1,6 @@
 var version = require('../../package.json').version;
 var grainstore = require('grainstore');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var tilelive = require('tilelive');
 
 module.exports = {

--- a/lib/windshaft/renderers/blend/factory.js
+++ b/lib/windshaft/renderers/blend/factory.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var queue = require('queue-async');
 var _ = require('underscore');
 

--- a/lib/windshaft/renderers/blend/renderer.js
+++ b/lib/windshaft/renderers/blend/renderer.js
@@ -1,4 +1,4 @@
-var blend = require('mapnik').blend;
+var blend = require('@carto/mapnik').blend;
 var queue = require('queue-async');
 var Timer = require('../../stats/timer');
 var _ = require('underscore');

--- a/lib/windshaft/renderers/http/renderer.js
+++ b/lib/windshaft/renderers/http/renderer.js
@@ -1,6 +1,6 @@
 var request = require('request');
 var Timer = require('../../stats/timer');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 
 function Renderer(urlTemplate, subdomains, options) {
     this.urlTemplate = urlTemplate;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -10,7 +10,7 @@ var BaseAdaptor = require('../base_adaptor');
 var DefaultQueryRewriter = require('../../utils/default_query_rewriter');
 
 require('tilelive-mapnik').registerProtocols(tilelive);
-require('tilelive-bridge').registerProtocols(tilelive);
+require('@carto/tilelive-bridge').registerProtocols(tilelive);
 
 var COLUMN_TYPE_GEOMETRY = 'geometry';
 var COLUMN_TYPE_RASTER = 'raster';

--- a/lib/windshaft/renderers/plain/color_renderer.js
+++ b/lib/windshaft/renderers/plain/color_renderer.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var Timer = require('../../stats/timer');
 
 function ColorRenderer(mapnikColor, options) {

--- a/lib/windshaft/renderers/plain/factory.js
+++ b/lib/windshaft/renderers/plain/factory.js
@@ -1,4 +1,4 @@
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var ColorRenderer = require('./color_renderer');
 var ImageRenderer = require('./image_renderer');
 var BaseAdaptor = require('../base_adaptor');

--- a/lib/windshaft/renderers/plain/image_renderer.js
+++ b/lib/windshaft/renderers/plain/image_renderer.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var blend = mapnik.blend;
 var step = require('step');
 var Timer = require('../../stats/timer');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "4.2.1",
+    "version": "4.3.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "cartodb-psql": "^0.10.1",
         "debug": "^3.1.0",
         "dot": "~1.0.2",
-        "grainstore": "~1.8.0",
+        "grainstore": "~1.8.1",
         "@carto/mapnik": "3.6.2-carto.1",
         "queue-async": "~1.0.7",
         "redis-mpool": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
         "Daniel Garcia Aubert <dgaubert@carto.com>"
     ],
     "dependencies": {
-        "abaculus": "cartodb/abaculus#2.0.3-cdb1",
+        "abaculus": "cartodb/abaculus#2.0.3-cdb2",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
         "cartodb-psql": "^0.10.1",
         "debug": "^3.1.0",
         "dot": "~1.0.2",
         "grainstore": "~1.8.0",
-        "mapnik": "3.5.14",
+        "@carto/mapnik": "3.6.2-carto.1",
         "queue-async": "~1.0.7",
         "redis-mpool": "0.4.1",
         "request": "^2.83.0",
@@ -36,8 +36,8 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-bridge": "cartodb/tilelive-bridge#2.3.1-cdb4",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb3",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb1",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb4",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },

--- a/test/acceptance/layer-filtering-regressions.js
+++ b/test/acceptance/layer-filtering-regressions.js
@@ -1,6 +1,6 @@
 require('../support/test_helper');
 
-const mapnik = require('mapnik');
+const mapnik = require('@carto/mapnik');
 
 const assert = require('../support/assert');
 const TestClient = require('../support/test_client');

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -4,7 +4,7 @@ var assert = require('../support/assert');
 var _ = require('underscore');
 var fs = require('fs');
 var step = require('step');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var http = require('http');
 
 var debug = require('debug')('windshaft:test');

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -2,7 +2,7 @@ require('../support/test_helper');
 
 var assert = require('../support/assert');
 var TestClient = require('../support/test_client');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 
 describe('mvt (mapnik)', function () {
     mvtTest(false);

--- a/test/acceptance/server_gettile.js
+++ b/test/acceptance/server_gettile.js
@@ -1,7 +1,7 @@
 require('../support/test_helper');
 
 var assert = require('../support/assert');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var semver = require('semver');
 var TestClient = require('../support/test_client');
 

--- a/test/acceptance/static_maps.js
+++ b/test/acceptance/static_maps.js
@@ -5,7 +5,7 @@ var TestClient = require('../support/test_client');
 var http = require('http');
 var fs = require('fs');
 var Renderer = require('../../lib/windshaft/renderers/http/renderer');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var assert = require('../support/assert');
 
 describe('static_maps', function() {

--- a/test/acceptance/vector-layergroup.js
+++ b/test/acceptance/vector-layergroup.js
@@ -1,7 +1,7 @@
 require('../support/test_helper');
 
 const assert = require('../support/assert');
-const mapnik = require('mapnik');
+const mapnik = require('@carto/mapnik');
 const TestClient = require('../support/test_client');
 const invalidFormatErrorTemplate = format => `Unsupported format: 'cartocss' option is missing for ${format}`;
 const INCOMPATIBLE_LAYERS_ERROR = 'The `mapnik` or `cartodb` layers must be consistent:' +

--- a/test/acceptance/zoom-min-max.js
+++ b/test/acceptance/zoom-min-max.js
@@ -1,6 +1,6 @@
 require('../support/test_helper');
 
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 
 var assert = require('../support/assert');
 var TestClient = require('../support/test_client');

--- a/test/integration/renderers/plain_image_renderer.js
+++ b/test/integration/renderers/plain_image_renderer.js
@@ -2,7 +2,7 @@ require('../../support/test_helper.js');
 
 var assert = require('assert');
 var fs = require('fs');
-var Image = require('mapnik').Image;
+var Image = require('@carto/mapnik').Image;
 
 var ImageRenderer = require('../../../lib/windshaft/renderers/plain/image_renderer');
 

--- a/test/integration/static_maps.js
+++ b/test/integration/static_maps.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var windshaft = require('../../lib/windshaft');
 var DummyMapConfigProvider = require('../../lib/windshaft/models/providers/dummy_mapconfig_provider');
 
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 //var RedisPool = require('redis-mpool');
 
 describe('static_maps', function() {

--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var path = require('path');
 var util = require('util');
 
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var debug = require('debug')('windshaft:assert');
 
 var assert = module.exports = exports = require('assert');

--- a/test/support/server_options.js
+++ b/test/support/server_options.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 
 module.exports = (function(opts) {
 

--- a/test/support/test_client.js
+++ b/test/support/test_client.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var mapnik = require('mapnik');
+var mapnik = require('@carto/mapnik');
 var RedisPool = require('redis-mpool');
 
 var windshaft = require('../../lib/windshaft');


### PR DESCRIPTION
New features:
 - Now mapnik has support for fine-grained metrics.
 - Variables can be passed for later substitution in postgis datasource.

Announcements:
 - Upgrade mapnik to @carto/mapnik 3.6.2-carto.1, which uses carto lib mapnik v3.0.15.2 underneath. See https://github.com/CartoDB/mapnik/blob/v3.0.15-carto/CHANGELOG.carto.md and https://github.com/CartoDB/mapnik/blob/v3.0.15-carto/CHANGELOG.carto.md
 - Upgrade tilelive-bridge to @carto/tilelive-bridge 2.5.1-cdb1. See https://github.com/CartoDB/tilelive-bridge/blob/cdb-2.x/CHANGELOG.carto.md
 - Upgrade tilelive-mapnik to 0.6.18-cdb4
 - Upgrade abaculus to 2.0.3-cdb2
 - Upgrade grainstore to 1.8.1
 - Use yarn instead of npm
 - Use the script docker-test.sh for travis builds