### PR TITLE
Adapt Mapnik metrics into single objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 2018-XX-XX
 
 Announcements:
- - 
+ - Mapnik metrics: Use several individual objects instead of children 
 
 # Version 4.5.0
 2018-02-06

--- a/lib/windshaft/renderers/mapnik/adaptor.js
+++ b/lib/windshaft/renderers/mapnik/adaptor.js
@@ -1,5 +1,14 @@
 var wrap = require('../base_adaptor').wrap;
 
+function parseMapnikMetrics(stats) {
+    if (stats && stats.hasOwnProperty('Mapnik')) {
+        stats.Mk_Setup = stats.Mapnik.Setup['Time (us)'] / 1000;
+        stats.Mk_Render = stats.Mapnik.Render['Time (us)'] / 1000;
+        stats.Mk_FeatNum = stats.Mapnik.Render.Style.features;
+        delete stats.Mapnik;
+    }
+}
+
 function TileliveAdaptor(renderer, format, onTileErrorStrategy) {
     this.renderer = renderer;
     this.close = this.renderer.close.bind(this.renderer);
@@ -8,6 +17,7 @@ function TileliveAdaptor(renderer, format, onTileErrorStrategy) {
         if (onTileErrorStrategy) {
             this.getTile = function(z, x, y, callback) {
                 renderer.getTile(z, wrap(x, z), y, function(err, tile, headers, stats) {
+                    parseMapnikMetrics(stats);
                     if (err) {
                         return onTileErrorStrategy(err, tile, headers, stats, format, callback);
                     } else {


### PR DESCRIPTION
Turns something like this:
```
{
   render:17,
   encode:7,
   Mapnik:{
      'Time (us)':16617,
      Calls:1,
      Setup:{
         'Time (us)':3671,
         Calls:1,
         'Datasource: Get Features':{
            'Time (us)':3643,
            Calls:1
         }
      },
      Render:{
         'Time (us)':11206,
         Calls:1,
         Style:{
            'Time (us)':11200,
            Calls:1,
            features:246
         }
      }
   }
}
```

Into something like this:
```
{
   render:17,
   encode:7,
   Mk_Setup:3.671,
   Mk_Render:11.206,
   Mk_FeatNum:246
}
```

This is needed for 2 reasons:
* Decrease the size of the payload in the header (which was an extra ~200B per tile).
* Compatibility with logstash / ElasticSearch.