### PR TITLE
 AttributesBackend: Allow multiple points if all the attributes are  the same 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 Announcements:
  - AttributesBackend: Allow multiple points if all the attributes are the same
+ - Update tilelive-mapnik#0.6.18-cdb7 (Avoids node-mapnik conflict)
 
 # Version 4.5.3
 2018-02-13

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 Announcements:
  - AttributesBackend: Allow multiple points if all the attributes are the same
- - Update tilelive-mapnik#0.6.18-cdb7 (Avoids node-mapnik conflict)
+ - Avoids mapnik conflict: Update tilelive-mapnik#0.6.18-cdb7, tilelive-bridge#2.5.1-cdb3
 
 # Version 4.5.3
 2018-02-13

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # Version 4.5.4
-2018-02-13
+2018-XX-XX
 
 Announcements:
- -
+ - AttributesBackend: Allow multiple points if all the attributes are the same
 
 # Version 4.5.3
 2018-02-13

--- a/lib/windshaft/backends/attributes.js
+++ b/lib/windshaft/backends/attributes.js
@@ -84,7 +84,7 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
                 pixel_height: '1'
             });
 
-            var sql = 'select ' + quoted_att_cols + ' from ( ' + layerSql + ' ) as _windshaft_subquery ';
+            var sql = 'SELECT DISTINCT ' + quoted_att_cols + ' FROM ( ' + layerSql + ' ) AS _windshaft_subquery';
             if ( ! testMode ) {
                 sql += ' WHERE ' + pg.quoteIdentifier(fid_col) + ' = ' + params.fid;
             } else {

--- a/lib/windshaft/backends/attributes.js
+++ b/lib/windshaft/backends/attributes.js
@@ -33,6 +33,7 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
     var timer = new Timer();
 
     var mapConfig;
+    var fid_col;
     step(
         function getMapConfig() {
             mapConfigProvider.getMapConfig(this);
@@ -64,7 +65,7 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
             //       means it is well-formed (should be checked at
             //       MapConfig construction/validation time).
 
-            var fid_col = attributes.id;
+            fid_col = attributes.id;
             var att_cols = attributes.columns;
 
             // prepare columns with double quotes
@@ -101,8 +102,8 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
                     return null;
                 }
                 else {
-                    var rowsLengthError = new Error(data.rows.length + " features in layer " + params.layer +
-                        " are identified by fid " + params.fid);
+                    var rowsLengthError = new Error("Multiple features (" + data.rows.length + ") identified by '" +
+                            fid_col + "' = " + params.fid + " in layer " + params.layer);
                     if ( ! data.rows.length ) {
                         rowsLengthError.http_status = 404;
                     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "dependencies": {
         "@carto/mapnik": "3.6.2-carto.2",
-        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb1",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb3",
         "abaculus": "cartodb/abaculus#2.0.3-cdb2",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb5",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb7",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -93,6 +93,6 @@ else
 fi
 ret=$?
 
-#cleanup
+cleanup
 
 exit $ret

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -128,17 +128,15 @@ describe('attributes', function() {
         var substitutionTokenSql = [
             "SELECT",
             "    1 as i,",
-            "    '!scale_denominator!' as scale_denominator,",
-            "    '!bbox!' as bbox,",
-            "    '!pixel_width!' as pixel_width,",
-            "    '!pixel_height!' as pixel_height,",
+            "    !scale_denominator! as scale_denominator,",
+            "    !pixel_width! as pixel_width,",
+            "    !pixel_height! as pixel_height,",
             "    6 as n,",
             "    'SRID=4326;POINT(0 0)'::geometry as the_geom"
         ].join('\n');
 
         var expectedAttributes = {
             scale_denominator: '0',
-            bbox: 'ST_MakeEnvelope(-20037508.34,-20037508.34,20037508.34,20037508.34,3857)',
             pixel_width: '1',
             pixel_height: '1',
             n: 6


### PR DESCRIPTION
The idea is that if there are several points in the map in the same position but all have the same attributes (for the requested columns) we'll return those common attributes instead of an error. If the attributes are different we'd still return an error. 

Related to https://github.com/CartoDB/support/issues/1298

Also re-enables test cleanup that I pushed by mistake.