### PR TITLE
AttributesBackend: Support distinct and json_agg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # Version 4.5.6
-2018-XX-XX
+2018-03-12
 
 Announcements:
- -
+ - AttributesBackend: Support distinct and json_agg
 
 # Version 4.5.5
 2018-03-12

--- a/lib/windshaft/backends/attributes.js
+++ b/lib/windshaft/backends/attributes.js
@@ -84,7 +84,7 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
                 pixel_height: '1'
             });
 
-            var sql = 'SELECT DISTINCT ' + quoted_att_cols + ' FROM ( ' + layerSql + ' ) AS _windshaft_subquery';
+            var sql = 'SELECT ' + quoted_att_cols + ' FROM ( ' + layerSql + ' ) AS _windshaft_subquery';
             if ( ! testMode ) {
                 sql += ' WHERE ' + pg.quoteIdentifier(fid_col) + ' = ' + params.fid;
             } else {
@@ -102,6 +102,14 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
                     return null;
                 }
                 else {
+                    if (data.rows.length > 1) {
+                        // Check if they are actually different
+                        const uniqueAttributes = [...new Set(data.rows.map(r => JSON.stringify(r)))];
+                        if (uniqueAttributes.length === 1) {
+                            return data.rows[0];
+                        }
+                    }
+
                     var rowsLengthError = new Error("Multiple features (" + data.rows.length + ") identified by '" +
                             fid_col + "' = " + params.fid + " in layer " + params.layer);
                     if ( ! data.rows.length ) {

--- a/lib/windshaft/backends/attributes.js
+++ b/lib/windshaft/backends/attributes.js
@@ -103,7 +103,9 @@ AttributesBackend.prototype.getFeatureAttributes = function (mapConfigProvider, 
                 }
                 else {
                     if (data.rows.length > 1) {
-                        // Check if they are actually different
+                        // If we receive more than one row for the id (usually `cartodb_id`)
+                        // we want to check that the attributes received are truly different before
+                        // returning an error.
                         const uniqueAttributes = [...new Set(data.rows.map(r => JSON.stringify(r)))];
                         if (uniqueAttributes.length === 1) {
                             return data.rows[0];

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -61,6 +61,18 @@ describe('attributes', function() {
 
     });
 
+
+    it("can be fetched with json_agg column", function(done) {
+        var sql = "SELECT 1 as i, 6 as n, 'SRID=4326;POINT(0 0)'::geometry as the_geom, " +
+                  "json_agg(row_to_json((SELECT r FROM (SELECT 1 as d, 'Samuel' as name) r),true)) as data";
+        var testClient = new TestClient(createMapConfig(sql, 'i', ['n', 'data']));
+        testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
+            assert.ok(!err);
+            assert.deepEqual(attributes, { n: 6, data: [ { d: 1, name: 'Samuel' } ] });
+            done();
+        });
+    });
+
     it("can be fetched with duplicated id if as all attributes are the same ", function(done) {
 
         var testClient = new TestClient(createMapConfig());
@@ -70,6 +82,22 @@ describe('attributes', function() {
             done();
         });
 
+    });
+
+    it("can be fetched with duplicated id if as all attributes are the same with json_agg", function(done) {
+
+        var sql = "SELECT 1 as i, 6 as n, 'SRID=4326;POINT(0 0)'::geometry as the_geom, " +
+                  "json_agg(row_to_json((SELECT r FROM (SELECT 1 as d, 'Samuel' as name) r),true)) as data " +
+                  "UNION ALL " +
+                  "SELECT 1 as i, 6 as n, 'SRID=4326;POINT(0 0)'::geometry as the_geom, " +
+                  "json_agg(row_to_json((SELECT r FROM (SELECT 1 as d, 'Samuel' as name) r),true)) as data";
+
+        var testClient = new TestClient(createMapConfig(sql, 'i', ['n', 'data']));
+        testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
+            assert.ok(!err);
+            assert.deepEqual(attributes, { n: 6, data: [ { d: 1, name: 'Samuel' } ] });
+            done();
+        });
     });
 
     it("cannot be fetched with duplicated id if not all attributes are the same ", function(done) {


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1380

Since there is no comparison operator for json objects in Postgresql, the DISTINCT with json_agg failed, so I've moved the comparisons to js instead of the query.