### PR TITLE
Fix bug when parsing incomplete Mapnik metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# Version 4.5.6
-2018-XX-XX
+# Version 4.5.7
+2018-03-13
 
 Announcements:
- -
+ - Fix bug when parsing incomplete Mapnik metrics
 
 # Version 4.5.6
 2018-03-12

--- a/lib/windshaft/renderers/mapnik/adaptor.js
+++ b/lib/windshaft/renderers/mapnik/adaptor.js
@@ -1,15 +1,22 @@
 var wrap = require('../base_adaptor').wrap;
 
 function parseMapnikMetrics(stats) {
+    /*jshint maxcomplexity:20 */
     if (stats && stats.hasOwnProperty('Mapnik')) {
         const setup = ((stats.Mapnik || {}).Setup || {})['Time (us)'];
-        if (setup) stats.Mk_Setup = setup / 1000;
+        if (setup) {
+            stats.Mk_Setup = setup / 1000;
+        }
 
         const render = ((stats.Mapnik || {}).Render || {})['Time (us)'];
-        if (render) stats.Mk_Render = render / 1000;
+        if (render) {
+            stats.Mk_Render = render / 1000;
+        }
 
         const features = ((((stats.Mapnik) || {}).Render || {}).Style || {}).features;
-        if (features) stats.Mk_FeatNum = features;
+        if (features) {
+            stats.Mk_FeatNum = features;
+        }
 
         delete stats.Mapnik;
     }

--- a/lib/windshaft/renderers/mapnik/adaptor.js
+++ b/lib/windshaft/renderers/mapnik/adaptor.js
@@ -1,22 +1,31 @@
 var wrap = require('../base_adaptor').wrap;
 
+function parseSetupTimeMetric(stats = {}) {
+    const setup = (stats.Mapnik.Setup || {})['Time (us)'];
+    if (setup) {
+        stats.Mk_Setup = setup / 1000;
+    }
+}
+
+function parseRenderTimeMetric(stats = {}) {
+    const render = (stats.Mapnik.Render || {})['Time (us)'];
+    if (render) {
+        stats.Mk_Render = render / 1000;
+    }
+}
+
+function parseFeatureNumberMetric(stats = {}) {
+    const features = ((stats.Mapnik.Render || {}).Style || {}).features;
+    if (features) {
+        stats.Mk_FeatNum = features;
+    }
+}
+
 function parseMapnikMetrics(stats) {
-    /*jshint maxcomplexity:20 */
     if (stats && stats.hasOwnProperty('Mapnik')) {
-        const setup = ((stats.Mapnik || {}).Setup || {})['Time (us)'];
-        if (setup) {
-            stats.Mk_Setup = setup / 1000;
-        }
-
-        const render = ((stats.Mapnik || {}).Render || {})['Time (us)'];
-        if (render) {
-            stats.Mk_Render = render / 1000;
-        }
-
-        const features = ((((stats.Mapnik) || {}).Render || {}).Style || {}).features;
-        if (features) {
-            stats.Mk_FeatNum = features;
-        }
+        parseSetupTimeMetric(stats);
+        parseRenderTimeMetric(stats);
+        parseFeatureNumberMetric(stats);
 
         delete stats.Mapnik;
     }

--- a/lib/windshaft/renderers/mapnik/adaptor.js
+++ b/lib/windshaft/renderers/mapnik/adaptor.js
@@ -2,9 +2,15 @@ var wrap = require('../base_adaptor').wrap;
 
 function parseMapnikMetrics(stats) {
     if (stats && stats.hasOwnProperty('Mapnik')) {
-        stats.Mk_Setup = stats.Mapnik.Setup['Time (us)'] / 1000;
-        stats.Mk_Render = stats.Mapnik.Render['Time (us)'] / 1000;
-        stats.Mk_FeatNum = stats.Mapnik.Render.Style.features;
+        const setup = ((stats.Mapnik || {}).Setup || {})['Time (us)'];
+        if (setup) stats.Mk_Setup = setup / 1000;
+
+        const render = ((stats.Mapnik || {}).Render || {})['Time (us)'];
+        if (render) stats.Mk_Render = render / 1000;
+
+        const features = ((((stats.Mapnik) || {}).Render || {}).Style || {}).features;
+        if (features) stats.Mk_FeatNum = features;
+
         delete stats.Mapnik;
     }
 }

--- a/test/acceptance/raster.js
+++ b/test/acceptance/raster.js
@@ -180,6 +180,46 @@ describe('raster', function() {
                 done();
             });
         });
+
+        it("Doesn't crash when only part of the metrics are returned " +
+           "[Strategy: " + (strat ? strat.name : "undefined") + ". Format: " + format + ")", function(done) {
+            // Mapconfig without render for zooms < 10
+            var mapconfig =  {
+                version: '1.2.0',
+                layers: [
+                    {
+                        type: 'mapnik',
+                        options: {
+                            sql: "select 1 as cartodb_id, ST_AsRaster(" +
+                                " ST_MakeEnvelope(-100,-40, 100, 40, 4326), " +
+                                " 1.0, -1.0, '8BUI', 127) as the_geom_webmercator",
+                            geom_column: 'the_geom_webmercator',
+                            geom_type: 'raster',
+                            cartocss: '#query_test[zoom >= 10] {#layer { raster-opacity:1.0 }}',
+                            cartocss_version: '2.0.1'
+                        }
+                    }
+                ]
+            };
+
+            if (format === "grid.json") {
+                delete mapconfig.layers[0].options.geom_column;
+                delete mapconfig.layers[0].options.geom_type;
+                mapconfig.layers[0].options.interactivity = [ 'cartodb_id' ];
+            }
+
+            var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } }, strat);
+            testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
+                assert.ok(!err);
+                assert(!stats.Mapnik);
+                assert(stats.Mk_Setup);
+                assert(!stats.Mk_Render);
+                assert(!stats.Mk_FeatNum);
+                done();
+            });
+
+        });
+
     });
     });
 });


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1374

When partial metrics were returned from Mapnik (due to not rendering anything for example) an error appeared as it tried to read from an undefined object