### PR TITLE
Update @carto/mapnik to 3.6.2-carto.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Version 4.6.0
+2018-mm-dd
+
+Announcements:
+ - Update @carto/mapnik to 3.6.2-carto.4. Also update tilelive-mapnik, tilelive-bridge and abaculus accordingly. That version includes a cache for rasterized symbols. See https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto4
+
 # Version 4.5.7
 2018-03-14
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,14 @@
 
 Announcements:
  - Update @carto/mapnik to 3.6.2-carto.4. Also update tilelive-mapnik, tilelive-bridge and abaculus accordingly. That version includes a cache for rasterized symbols. See https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto4
+ - PostGIS: Variables in postgis SQL queries must now additionally be wrapped in `!` (refs [#29](https://github.com/CartoDB/mapnik/issues/29), [mapnik/#3618](https://github.com/mapnik/mapnik/pull/3618)):
+```sql
+-- Before
+SELECT ... WHERE trait = @variable
+
+-- Now
+SELECT ... WHERE trait = !@variable!
+```
 
 # Version 4.5.7
 2018-03-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "4.5.7",
+    "version": "4.6.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [
@@ -21,9 +21,9 @@
         "Daniel Garcia Aubert <dgaubert@carto.com>"
     ],
     "dependencies": {
-        "@carto/mapnik": "3.6.2-carto.2",
-        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb3",
-        "abaculus": "cartodb/abaculus#2.0.3-cdb2",
+        "@carto/mapnik": "3.6.2-carto.4",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb4",
+        "abaculus": "cartodb/abaculus#2.0.3-cdb5",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
         "cartodb-psql": "^0.10.1",
@@ -37,7 +37,7 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb7",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb8",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },


### PR DESCRIPTION
Update `@carto/mapnik` and all dependencies that in turn depend on it to
that version.

It brings a cache for rasterized symbols.

Also bump package minor version and update NEWS.md

cc'ing @Algunenano and @dgaubert mostly for awareness. Here's my plan for this:
- Get as much as I can ready in advance about packaging, to be able to deploy at a press of a button. This is almost the last step.
- Get some prod metrics to compare against.
- Deploy and check metrics
- Celebrate with the victory dance :man_dancing: 