### PR TITLE
Config for markers symbolizer caches [WIP]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-# Version 4.6.1
+# Version 4.7.0
 2018-mm-dd
 
 Announcements:
  - Adding Redis v4 in Dockerfile
- - Update @carto/mapnik to [`3.6.2-carto.6`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto6). Also update tilelive-mapnik, tilelive-bridge and abaculus accordingly.
+ - Update @carto/mapnik to [`3.6.2-carto.7`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto7). Also update tilelive-mapnik, tilelive-bridge and abaculus accordingly. It brings some improvements for markers symbolizer caches as well as more performance metrics and configuration options.
+ - Add a config option to disable `markers_symbolizer_caches`.
 
 # Version 4.6.0
 2018-03-15

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -152,8 +152,8 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
         params.metrics = this._mapnik_opts.metrics;
     }
 
-    if (params.rasterized_symbols_cache_disabled === undefined) {
-        params.rasterized_symbols_cache_disabled = this._mapnik_opts.rasterized_symbols_cache_disabled;
+    if (params.markers_symbolizer_caches_disabled === undefined) {
+        params.markers_symbolizer_caches_disabled = this._mapnik_opts.markers_symbolizer_caches.disabled;
     }
 };
 
@@ -198,7 +198,6 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
         },
         function loadMapnik(err, xml) {
             assert.ifError(err);
-            console.log('RTORRE: xml = ' + xml);
 
             var query = {
                 metatile: self.getMetatile(format),
@@ -277,7 +276,7 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         extra_ds_opts: [],
         gcols: [],
         'cache-features': rendererOptions.params['cache-features'],
-        rasterized_symbols_cache_disabled: rendererOptions.rasterized_symbols_cache_disabled
+        markers_symbolizer_caches_disabled: rendererOptions.params.markers_symbolizer_caches_disabled
     };
 
     var layerFilter = rendererOptions.layer;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -36,7 +36,6 @@ function MapnikFactory(options) {
     this._options = options;
 
     // Set default mapnik options
-    console.log('RTORRE: options.mapnik.rasterized_symbols_cache_disabled = ' + (options.mapnik && options.mapnik.rasterized_symbols_cache_disabled));
     this._mapnik_opts = _.defaults(options.mapnik || {}, {
 
         geometry_field: 'the_geom_webmercator',

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -36,6 +36,7 @@ function MapnikFactory(options) {
     this._options = options;
 
     // Set default mapnik options
+    console.log('RTORRE: options.mapnik.rasterized_symbols_cache_disabled = ' + (options.mapnik && options.mapnik.rasterized_symbols_cache_disabled));
     this._mapnik_opts = _.defaults(options.mapnik || {}, {
 
         geometry_field: 'the_geom_webmercator',
@@ -109,7 +110,9 @@ function MapnikFactory(options) {
         'cache-features': true,
 
         // Require stats per query to the renderer
-        metrics: false
+        metrics: false,
+
+        rasterized_symbols_cache_disabled: false
     });
 
     this.tile_scale_factors = this._mapnik_opts.scale_factors.reduce(function(previousValue, currentValue) {
@@ -145,6 +148,11 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
 
     if (params.metrics === undefined) {
         params.metrics = this._mapnik_opts.metrics;
+    }
+
+    if (params.rasterized_symbols_cache_disabled === undefined) {
+        console.log("RTORRE: here");
+        params.rasterized_symbols_cache_disabled = this._mapnik_opts.rasterized_symbols_cache_disabled;
     }
 };
 
@@ -189,6 +197,7 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
         },
         function loadMapnik(err, xml) {
             assert.ifError(err);
+            console.log('RTORRE: xml = ' + xml);
 
             var query = {
                 metatile: self.getMetatile(format),
@@ -200,7 +209,7 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
                 autoLoadFonts: false,
                 internal_cache: false,
                 limits: limits,
-                metrics: options.params.metrics
+                metrics: options.params.metrics,
             };
 
             var isMvt = format === FORMAT_MVT;
@@ -266,7 +275,8 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         datasource_extend: [],
         extra_ds_opts: [],
         gcols: [],
-        'cache-features': rendererOptions.params['cache-features']
+        'cache-features': rendererOptions.params['cache-features'],
+        rasterized_symbols_cache_disabled: rendererOptions.rasterized_symbols_cache_disabled
     };
 
     var layerFilter = rendererOptions.layer;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -153,7 +153,6 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
     }
 
     if (params.rasterized_symbols_cache_disabled === undefined) {
-        console.log("RTORRE: here");
         params.rasterized_symbols_cache_disabled = this._mapnik_opts.rasterized_symbols_cache_disabled;
     }
 };

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -152,8 +152,8 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
         params.metrics = this._mapnik_opts.metrics;
     }
 
-    if (params.markers_symbolizer_caches_disabled === undefined) {
-        params.markers_symbolizer_caches_disabled = this._mapnik_opts.markers_symbolizer_caches.disabled;
+    if (params.markers_symbolizer_caches === undefined) {
+        params.markers_symbolizer_caches = this._mapnik_opts.markers_symbolizer_caches;
     }
 };
 

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -111,7 +111,10 @@ function MapnikFactory(options) {
         // Require stats per query to the renderer
         metrics: false,
 
-        rasterized_symbols_cache_disabled: false
+        // Options for markers attributes, ellipses and images caches
+        markers_symbolizer_caches: {
+            disabled: false
+        }
     });
 
     this.tile_scale_factors = this._mapnik_opts.scale_factors.reduce(function(previousValue, currentValue) {

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -275,8 +275,7 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         datasource_extend: [],
         extra_ds_opts: [],
         gcols: [],
-        'cache-features': rendererOptions.params['cache-features'],
-        markers_symbolizer_caches_disabled: rendererOptions.params.markers_symbolizer_caches_disabled
+        'cache-features': rendererOptions.params['cache-features']
     };
 
     var layerFilter = rendererOptions.layer;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -109,12 +109,7 @@ function MapnikFactory(options) {
         'cache-features': true,
 
         // Require stats per query to the renderer
-        metrics: false,
-
-        // Options for markers attributes, ellipses and images caches
-        markers_symbolizer_caches: {
-            disabled: false
-        }
+        metrics: false
     });
 
     this.tile_scale_factors = this._mapnik_opts.scale_factors.reduce(function(previousValue, currentValue) {
@@ -152,7 +147,7 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
         params.metrics = this._mapnik_opts.metrics;
     }
 
-    if (params.markers_symbolizer_caches === undefined) {
+    if (params.markers_symbolizer_caches === undefined && this._mapnik_opts.markers_symbolizer_caches) {
         params.markers_symbolizer_caches = this._mapnik_opts.markers_symbolizer_caches;
     }
 };

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -209,7 +209,7 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
                 autoLoadFonts: false,
                 internal_cache: false,
                 limits: limits,
-                metrics: options.params.metrics,
+                metrics: options.params.metrics
             };
 
             var isMvt = format === FORMAT_MVT;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "4.6.1",
+    "version": "4.7.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [
@@ -21,9 +21,9 @@
         "Daniel Garcia Aubert <dgaubert@carto.com>"
     ],
     "dependencies": {
-        "@carto/mapnik": "3.6.2-carto.6",
-        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb5",
-        "abaculus": "cartodb/abaculus#2.0.3-cdb6",
+        "@carto/mapnik": "3.6.2-carto.7",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb6",
+        "abaculus": "cartodb/abaculus#2.0.3-cdb7",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
         "cartodb-psql": "^0.10.1",
@@ -37,7 +37,7 @@
         "sphericalmercator": "1.0.4",
         "step": "~0.0.6",
         "tilelive": "5.12.2",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb9",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb10",
         "torque.js": "~2.11.0",
         "underscore": "~1.6.0"
     },


### PR DESCRIPTION
This fully relates to https://github.com/CartoDB/grainstore/pull/145 and https://github.com/CartoDB/mapnik/pull/43

The configuration was meant to mimic the original, "extensible" proposal:
```js
var config = {
    renderer: {
        mapnik: {
            markers_symbolizer_caches: {
                disabled: false,     // markers_symbolizer_caches_disabled_
                images: {
                    size: 4096,      // markers_symbolizer_images_cache_size_
                    sampling_rate: 8 // markers_symbolizer_images_cache_sampling_rate_
                },
                attributes_size: 256, // markers_symbolizer_attrs_cache_size_  
                ellipses_size: 256,   // markers_symbolizer_ellipses_cache_size_
            }
        }
    }
};
```

As discussed, unless we instantiate the caches per-map and as long as the caches are static, the size attributes do not make sense. But the plan was to keep it flexible enough w/o introducing unneeded code/configs.

There's a mapping between Windshaft config, parameters, mml, xml and the final per-map bool config setting. There will always be such mapping. Unless we wanted to keep configs more plain, I don't see a better way to deal with defaults in the multiple layers. Yet I'm open to suggestions