### PR TITLE
Add Mapnik metrics docs and extra tests

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -57,6 +57,23 @@ Again, each inner timer may have several inner timers, some of them are displaye
 - **windshaft.tiles.*{format}*.error**: per format number of tiles request that failed
 - **windshaft.tiles.*{format}*.success**: per format number of tiles request that succeeded
 
+## MAPNIK
+Currently any measure taken in Mapnik is also returned, with 'Mk_' prepended. Here is a list of the ones currently being used:
+
+### Timers:
+- **Mk_All**: The full amount of time (ms) spent in the Mapnik library (doesn't include any time spent in the node modules)
+- **Mk_Setup**: Time spent in the tasks needed to start the rendering (mainly DB).
+- **Mk_Datasource**: Time spent only the DB calls (included in 'Mk_Setup').
+- **Mk_Render**: Time spent rendering
+- **Mk_Render_Style:**: Time spent rendering the styles (included in 'Mk_Render').
+- **Mk_Agg_PXXS**: Time spent in the Agg renderer with the symbolizer 'XX', where 'XX' can be: 'Build', 'Debug', 'Dot', 'Group', 'LinePattern', 'Line', 'Marker', 'Point', 'Polygon', 'PolygonPattern', 'Raster', 'Shield', 'Text'.
+- **Mk_Grid_PXXS**: Time spent in the Grid renderer with the symbolizer 'XX', where 'XX' can be: 'Build', 'Group', 'LinePattern', 'Line', 'Marker', 'Point', 'Polygon', 'PolygonPattern', 'Raster', 'Shield', 'Text'.
+
+### Counters:
+- **Mk_Features_cnt_XX**: Number of features rendered of type 'XX', where 'XX' can be: 'Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon', 'GeometryCollection', 'Unknown'.
+- **Mk_Agg_PMS_AttrCache_Miss** and **Agg_PMS_EllipseCache_Miss**: In the render marker symbolizer, they count the cache misses for the attributes cache (and ellipse if applicable). Note: The hits can be calculated by substracting the number of features to this value.
+- **Mk_Agg_PMS_ImageCache_Miss** and **Agg_PMS_ImageCache_Ignored**: For the Agg renderer and Marker Symbolizer, they count the number of cache misses ('_Miss') and ignores ('_Ignored') which could be due to the cache being deactivated or the attributes not being cacheable (e.g. using scaling).
+
 \* ***{format}*** is one of the following:
 * png
 * grid_json

--- a/test/acceptance/metrics.js
+++ b/test/acceptance/metrics.js
@@ -128,6 +128,36 @@ describe('metrics', function() {
     });
     });
 
+    //TODO: Pending fix in tilelive-mapnik
+    it.skip("works with metatiles", function(done) {
+
+        var mapconfig =  {
+            version: '1.2.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        sql: "select 1 as cartodb_id, " +
+                            " ST_MakeEnvelope(-100,-40, 100, 40, 4326) " +
+                            " as the_geom_webmercator",
+                        geom_column: 'the_geom_webmercator',
+                        cartocss: '#layer { raster-opacity:1.0 }',
+                        cartocss_version: '2.0.1'
+                    }
+                }
+            ]
+        };
+
+        var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metatile: 2, metrics : true } } });
+        testClient.getTile(1, 1, 1, {format: 'png'}, function(err, tile, img, headers, stats) {
+            assert.ok(!err);
+            assert(!stats.hasOwnProperty('Mapnik'));
+            assert(stats.hasOwnProperty('Mk_Setup'));
+            assert(stats.hasOwnProperty('Mk_Render'));
+            done();
+        });
+    });
+
      describe('Geometry counts', function() {
 
         it("works with different geometry types", function(done) {

--- a/test/acceptance/metrics.js
+++ b/test/acceptance/metrics.js
@@ -126,77 +126,77 @@ describe('metrics', function() {
     });
     });
 
-    it("Geometry counts", function(done) {
+     describe('Geometry counts', function() {
+
+        it("works with different geometry types", function(done) {
 
             var mapconfig =  {
                 version: '1.2.0',
-                layers: [
-                    {
-                        type: 'mapnik',
-                        options: {
-                            sql:/* 3 POINTS */
-                                "SELECT 11 as c, ST_SetSRID(ST_MakePoint(-71.10434, 42.315),4326) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 12 as c, ST_SetSRID(ST_MakePoint(-75.10434, 42.315),4326) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 13 as c, ST_SetSRID(ST_MakePoint(-75.10434, 45.335),4326) as tgw" +
+                layers: [{
+                    type: 'mapnik',
+                    options: {
+                        sql:/* 3 POINTS */
+                            "SELECT 11 as c, ST_SetSRID(ST_MakePoint(-71.10434, 42.315),4326) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 12 as c, ST_SetSRID(ST_MakePoint(-75.10434, 42.315),4326) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 13 as c, ST_SetSRID(ST_MakePoint(-75.10434, 45.335),4326) as tgw" +
 
-                                /* 2 MULTIPOINTS */
-                                " UNION ALL " +
-                                "SELECT 21 as c, 'MULTIPOINT((-72.10 44.31), (40.41 -3.70))'::geometry as tgw" +
-                                " UNION ALL " +
-                                "SELECT 22 as c, 'MULTIPOINT((-73.10 42.31), (40.41 -3.70))'::geometry as tgw" +
+                            /* 2 MULTIPOINTS */
+                            " UNION ALL " +
+                            "SELECT 21 as c, 'MULTIPOINT((-72.10 44.31), (40.41 -3.70))'::geometry as tgw" +
+                            " UNION ALL " +
+                            "SELECT 22 as c, 'MULTIPOINT((-73.10 42.31), (40.41 -3.70))'::geometry as tgw" +
 
-                                /* 2 LINESTRINGS */
-                                " UNION ALL " +
-                                "SELECT 31 as c, ST_MakeLine(" +
-                                    "ST_SetSRID(ST_MakePoint(-71.10434, 42.315), 4326)," +
-                                    "ST_SetSRID(ST_MakePoint(-73.10434, 44.315), 4326)) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 32 as c, ST_MakeLine(" +
-                                    "ST_SetSRID(ST_MakePoint(-76.10434, 42.315), 4326)," +
-                                    "ST_SetSRID(ST_MakePoint(-72.10434, 44.315), 4326)) as tgw" +
+                            /* 2 LINESTRINGS */
+                            " UNION ALL " +
+                            "SELECT 31 as c, ST_MakeLine(" +
+                                "ST_SetSRID(ST_MakePoint(-71.10434, 42.315), 4326)," +
+                                "ST_SetSRID(ST_MakePoint(-73.10434, 44.315), 4326)) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 32 as c, ST_MakeLine(" +
+                                "ST_SetSRID(ST_MakePoint(-76.10434, 42.315), 4326)," +
+                                "ST_SetSRID(ST_MakePoint(-72.10434, 44.315), 4326)) as tgw" +
 
-                                /* 2 MULTILINESTRING */
-                                " UNION ALL " +
-                                "SELECT 41 as c, ST_Multi(ST_MakeLine(" +
-                                    "ST_SetSRID(ST_MakePoint(-71.10434, 42.315), 4326)," +
-                                    "ST_SetSRID(ST_MakePoint(-73.10434, 44.315), 4326))) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 42 as c, ST_Multi(ST_MakeLine(" +
-                                    "ST_SetSRID(ST_MakePoint(-76.10434, 42.315), 4326)," +
-                                    "ST_SetSRID(ST_MakePoint(-72.10434, 44.315), 4326))) as tgw" +
+                            /* 2 MULTILINESTRING */
+                            " UNION ALL " +
+                            "SELECT 41 as c, ST_Multi(ST_MakeLine(" +
+                                "ST_SetSRID(ST_MakePoint(-71.10434, 42.315), 4326)," +
+                                "ST_SetSRID(ST_MakePoint(-73.10434, 44.315), 4326))) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 42 as c, ST_Multi(ST_MakeLine(" +
+                                "ST_SetSRID(ST_MakePoint(-76.10434, 42.315), 4326)," +
+                                "ST_SetSRID(ST_MakePoint(-72.10434, 44.315), 4326))) as tgw" +
 
-                                /* 4 POLYGONS */
-                                " UNION ALL " +
-                                "SELECT 51 as c, ST_MakeEnvelope(-100,-40, 100, 40, 4326) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 52 as c, ST_MakeEnvelope(-100,-45, 100, 40, 4326) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 53 as c, ST_MakeEnvelope(-100,-45, 120, 40, 4326) as tgw" +
-                                " UNION ALL " +
-                                "SELECT 54 as c, ST_MakeEnvelope(-100,-45, 100, 44, 4326) as tgw" +
+                            /* 4 POLYGONS */
+                            " UNION ALL " +
+                            "SELECT 51 as c, ST_MakeEnvelope(-100,-40, 100, 40, 4326) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 52 as c, ST_MakeEnvelope(-100,-45, 100, 40, 4326) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 53 as c, ST_MakeEnvelope(-100,-45, 120, 40, 4326) as tgw" +
+                            " UNION ALL " +
+                            "SELECT 54 as c, ST_MakeEnvelope(-100,-45, 100, 44, 4326) as tgw" +
 
-                                /* 3 MUTIPOLYGON */
-                                " UNION ALL " +
-                                "SELECT 61 as c, ST_Multi(ST_MakeEnvelope(-100,-45, 100, 44, 4326)) as tgw"+
-                                " UNION ALL " +
-                                "SELECT 62 as c, ST_Multi(ST_MakeEnvelope(-130,-45, 3100, 44, 4326)) as tgw"+
-                                " UNION ALL " +
-                                "SELECT 63 as c, ST_Multi(ST_MakeEnvelope(-102,-45, 100, 44, 4326)) as tgw" +
+                            /* 3 MUTIPOLYGON */
+                            " UNION ALL " +
+                            "SELECT 61 as c, ST_Multi(ST_MakeEnvelope(-100,-45, 100, 44, 4326)) as tgw"+
+                            " UNION ALL " +
+                            "SELECT 62 as c, ST_Multi(ST_MakeEnvelope(-130,-45, 3100, 44, 4326)) as tgw"+
+                            " UNION ALL " +
+                            "SELECT 63 as c, ST_Multi(ST_MakeEnvelope(-102,-45, 100, 44, 4326)) as tgw" +
 
-                                /* 1 GEOMETRYCOLLECTION */
-                                " UNION ALL " +
-                                "SELECT 71 as c, "+
-                                "'GEOMETRYCOLLECTION(CIRCULARSTRING(22.022 15.040,22.202 15.040,22.022 15.040))" +
-                                "'::geometry as tgw",
+                            /* 1 GEOMETRYCOLLECTION */
+                            " UNION ALL " +
+                            "SELECT 71 as c, "+
+                            "'GEOMETRYCOLLECTION(CIRCULARSTRING(22.022 15.040,22.202 15.040,22.022 15.040))" +
+                            "'::geometry as tgw",
 
-                            geom_column: 'tgw',
-                            cartocss: '#layer { raster-opacity:1.0 }',
-                            cartocss_version: '2.0.1'
-                        }
+                        geom_column: 'tgw',
+                        cartocss: '#layer { raster-opacity:1.0 }',
+                        cartocss_version: '2.0.1'
                     }
-                ]
+                }]
             };
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
@@ -213,34 +213,32 @@ describe('metrics', function() {
             });
         });
 
-    it("Geometry counts with raster shows as unknown", function(done) {
+        it("shows unknown with raster", function(done) {
 
             var mapconfig =  {
-            version: '1.2.0',
-            layers: [
-                {
+                version: '1.2.0',
+                layers: [{
                     type: 'cartodb',
                     options: {
                         sql: /* 4 RASTERs */
-                                "SELECT 81 as c, " +
-                                "ST_AsRaster(ST_MakeEnvelope(-100,-40, 100, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
-                                " UNION ALL " +
-                                "SELECT 82 as c, " +
-                                "ST_AsRaster(ST_MakeEnvelope(-100,-45, 100, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
-                                " UNION ALL " +
-                                "SELECT 83 as c, " +
-                                "ST_AsRaster(ST_MakeEnvelope(-100,-45, 120, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
-                                " UNION ALL " +
-                                "SELECT 84 as c, " +
-                                "ST_AsRaster(ST_MakeEnvelope(-100,-45, 100, 44, 4326), 1.0, -1.0, '8BUI', 127) as rst",
+                            "SELECT 81 as c, " +
+                            "ST_AsRaster(ST_MakeEnvelope(-100,-40, 100, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
+                            " UNION ALL " +
+                            "SELECT 82 as c, " +
+                            "ST_AsRaster(ST_MakeEnvelope(-100,-45, 100, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
+                            " UNION ALL " +
+                            "SELECT 83 as c, " +
+                            "ST_AsRaster(ST_MakeEnvelope(-100,-45, 120, 40, 4326), 1.0, -1.0, '8BUI', 127) as rst" +
+                            " UNION ALL " +
+                            "SELECT 84 as c, " +
+                            "ST_AsRaster(ST_MakeEnvelope(-100,-45, 100, 44, 4326), 1.0, -1.0, '8BUI', 127) as rst",
                         geom_column: 'rst',
                         geom_type: 'raster',
                         cartocss: '#layer { raster-opacity:1.0 }',
                         cartocss_version: '2.0.1'
                     }
-                }
-            ]
-        };
+                }]
+            };
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {


### PR DESCRIPTION
Extra notes:
- Adds a disabled test for metatiles. Pending fix in tilelive-mapnik to enable it.
- Adds a disabled test with render time variables in the `sql`. Pending fix in tilelive-mapnik to enable it.
- Adds a disabled test for the Group Symbolizer. The `carto` module currently doesn't support, but I prefer to have it there for reference.
- The symbolizer tests could do something fancier than:
`assert(stats.hasOwnProperty('Mk_Agg_PGroupS') || stats.hasOwnProperty('Mk_Grid_PGroupS'));`,
like `assert(stats.hasOwnProperty('Mk_' + renderer + '_PGroupS') `, but I prefer this way as it leaves the whole metric name intact in case someone greps the source files looking for it.