### PR TITLE
Make POSTGIS_VERSION detection automatic

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -79,7 +79,7 @@ if test x"$OPT_CREATE" = xyes; then
   echo ${PID_REDIS} > ${BASEDIR}/redis.pid
 
   echo "Preparing the environment"
-  cd ${BASEDIR}/test; sh prepare_test || die "database preparation failure"; cd -
+  cd ${BASEDIR}/test; source prepare_test || die "database preparation failure"; cd -
 fi
 
 PATH=node_modules/.bin/:$PATH

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -6,4 +6,4 @@ npm install -g yarn@0.27.5
 yarn
 
 # run tests
-POSTGIS_VERSION=2.4 npm test
+npm test

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -8,7 +8,7 @@ describe('mvt (mapnik)', function () {
     mvtTest(false);
 });
 
-if (process.env.POSTGIS_VERSION === '2.4') {
+if (process.env.POSTGIS_VERSION >= '20400') {
     describe('mvt (pgsql)', function () {
         mvtTest(true);
     });

--- a/test/acceptance/vector-layergroup.js
+++ b/test/acceptance/vector-layergroup.js
@@ -26,7 +26,7 @@ describe('mvt (mapnik)', function () {
     mvtTest(false);
 });
 
-if (process.env.POSTGIS_VERSION === '2.4') {
+if (process.env.POSTGIS_VERSION >= '20400') {
     describe('mvt (pgsql)', function () {
         mvtTest(true);
     });

--- a/test/acceptance/zoom-min-max.js
+++ b/test/acceptance/zoom-min-max.js
@@ -240,7 +240,7 @@ describe('minzoom and maxzoom', function() {
         };
 
         const suiteConfigurations = [{ mvt: { usePostGIS: false } }];
-        if (process.env.POSTGIS_VERSION === '2.4') {
+        if (process.env.POSTGIS_VERSION >= '20400') {
             suiteConfigurations.push({ mvt: { usePostGIS: true } });
         }
 

--- a/test/prepare_test
+++ b/test/prepare_test
@@ -23,6 +23,20 @@ if [ -n "${pgPORT}" ]; then
   echo "PGPORT: [$PGPORT]"
 fi
 
+# Sets the env variable POSTGIS_VERSION as Major * 10000 + Minor * 100 + Patch
+# For example, for 2.4.5 ~> 20405
+auto_postgis_version() {
+    local POSTGIS_STR=$(psql -c "Select default_version from pg_available_extensions WHERE name = 'postgis';" -t);
+    local pg_version=$(echo $POSTGIS_STR | awk -F '.' '{print $1 * 10000 + $2 * 100 + $3}')
+
+    echo $pg_version
+}
+
+if [ -z "$POSTGIS_VERSION" ]; then
+    export POSTGIS_VERSION=$(auto_postgis_version)
+    echo "POSTGIS_VERSION: [$POSTGIS_VERSION]"
+fi
+
 die() {
         msg=$1
         echo "${msg}" >&2


### PR DESCRIPTION
Changes the behaviour to use `POSTGIS_VERSION` as Major * 10000 + Minor * 100 + Patch and make the detection automatic. Examples:
* `2.4.5` - 20405
* `2.2.1`- 20201
* `2.5.0beta1dev` - 20500