### PR TITLE
Skip attribute validation when sql_raw is present

### DIFF
--- a/lib/windshaft/backends/map_validator.js
+++ b/lib/windshaft/backends/map_validator.js
@@ -122,7 +122,8 @@ MapValidatorBackend.prototype.validate = function(mapConfigProvider, callback) {
                     }
 
                     // both 'cartodb' or 'torque' types can have attributes
-                    if (lyropt.attributes) {
+                    // attribute validation is usually very inefficient when sql_raw if present so we skip it
+                    if (lyropt.attributes && !lyropt.sql_raw) {
                         validateRemainingFormatLayerFns.push(validateAttributes(layerId));
                     }
                 });


### PR DESCRIPTION
This is a quick fix for #639

sql_raw presence indicates aggregation or other complex query wrapping is in place.
In these cases running a query with a whole-earth bbox as the attribute validation does can be very expensive (even with LIMIT 1, because the whole table must first be aggregated).

So here we avoid the problematic attribute validation altogether when sql_raw is present.
In particular, notice that:
* If no aggregations or other sql wrapping occurs, no sql_raw is present and validation is not skipped
* If aggregations are requested but they are not being applied (too few rows or wrong geometry type) sql_raw is also empty and validation is not skipped

We'll work on a better solution in #642