### PR TITLE
Update @carto/mapnik to 3.6.2-carto.11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,13 @@
 Announcements:
 - pg-mvt renderer: Match current Mapnik behaviour (Filter column with known types, same default buffer size, accept geom_column ifferent than `the_geom_webmercator`).
 - pg-mvt renderer: Remove undocummented filtering by `layer.options.columns`.
-- MVT tests: Compare outputs from Mapnik and pg-mvt renderers.
+- MVT tests: Compare outputs (tile and headers) from Mapnik and pg-mvt renderers.
+- Update deps:
+  - `@carto/mapnik` to [`3.6.2-carto.11`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto.11/CHANGELOG.carto.md#362-carto11): Geometries in MVTs created with the mapnik renderer will be simplified based on the layer extent instead of a static 256. This has impact in lines and polygon layers, both in results and performance since geometries were being oversimplified.
+  - `@carto/tilelive-bridge` to [`2.5.1-cdb10`](https://github.com/CartoDB/tilelive-bridge/blob/2.5.1-cdb10/CHANGELOG.carto.md#251-cdb10): MVT Mapnik renderer no longers returns error on empty tile, instead it returns an empty buffer.
+  - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
+  - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
+- MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
 
 # Version 4.8.3
 2018-07-19

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -46,6 +46,11 @@ function getLayerColumns(psql, layer) {
         if (layer._mvtColumns) {
             return resolve();
         }
+
+        if (!layer.options.sql) {
+            return reject("Missing sql for layer");
+        }
+
         const layerSQL = setDefaultTokens(layer.options.sql, 0, 0, 0);
         const limitedQuery = `SELECT * FROM (${layerSQL}) __windshaft_mvt_schema LIMIT 0;`;
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -45,11 +45,10 @@ module.exports = class PostgresVectorRenderer {
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        const emptyTileMsg = 'Tile does not exist';
         const subqueries = this._getLayerQueries({ z, x, y });
 
         if (subqueries.length === 0) {
-            return callback(new Error(emptyTileMsg));
+            return callback(null, new Buffer(0));
         }
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
@@ -67,14 +66,13 @@ module.exports = class PostgresVectorRenderer {
             }
 
             const mvt = extractMVT(data);
-            if (!mvt) {
-                return callback(new Error(emptyTileMsg));
-            }
-
-            const headers = { 'Content-Type': 'application/x-protobuf' };
+            const headers = {
+                'Content-Type': 'application/x-protobuf',
+                'x-tilelive-contains-data' : mvt ? true : false
+            };
             const stats = timer.getTimes();
 
-            return callback(null, mvt, headers, stats);
+            return callback(null, mvt || new Buffer(0), headers, stats);
         });
     }
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -45,11 +45,16 @@ module.exports = class PostgresVectorRenderer {
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        const subqueries = this._getLayerQueries({ z, x, y });
+        const headers = {
+            'Content-Type': 'application/x-protobuf',
+            'x-tilelive-contains-data' : false
+        };
 
+        const subqueries = this._getLayerQueries({ z, x, y });
         if (subqueries.length === 0) {
-            return callback(null, new Buffer(0));
+            return callback(null, new Buffer(0), headers);
         }
+
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
         const timer = new Timer();
@@ -66,10 +71,9 @@ module.exports = class PostgresVectorRenderer {
             }
 
             const mvt = extractMVT(data);
-            const headers = {
-                'Content-Type': 'application/x-protobuf',
-                'x-tilelive-contains-data' : mvt ? true : false
-            };
+            if (mvt) {
+                headers['x-tilelive-contains-data'] = true;
+            }
             const stats = timer.getTimes();
 
             return callback(null, mvt || new Buffer(0), headers, stats);

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
         "Daniel Garcia Aubert <dgaubert@carto.com>"
     ],
     "dependencies": {
-        "@carto/mapnik": "3.6.2-carto.10",
-        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb9",
-        "abaculus": "cartodb/abaculus#2.0.3-cdb10",
+        "@carto/mapnik": "3.6.2-carto.11",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb10",
+        "abaculus": "cartodb/abaculus#2.0.3-cdb11",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
         "cartodb-psql": "0.11.0",
@@ -37,7 +37,7 @@
         "sphericalmercator": "1.0.5",
         "step": "1.0.0",
         "tilelive": "5.12.3",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb14",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb15",
         "torque.js": "2.16.2",
         "underscore": "1.6.0"
     },

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -500,9 +500,9 @@ function mvtExtractComponents(geometry) {
     });
 }
 
-// Compares (with a tolerance of +- 2) an array of points
+// Compares (with a tolerance of +- 1) an array of points
 function mvtPointArray_cmp(arr1, arr2) {
-    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 2));
+    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 1));
     assert.equal(arr1.length, 0, "Items not found in Mapnik's: " + JSON.stringify(arr1));
 }
 

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -80,6 +80,17 @@ function mvtTest(usePostGIS) {
         });
     });
 
+    it('Layer without sql', function (done) {
+        const mapConfig = TestClient.singleLayerMapConfig('select * from test_table', null, null, 'name');
+        delete mapConfig.layers[0].options.sql;
+        const testClient = new TestClient(mapConfig, options);
+
+        testClient.getTile(13, 4011, 3088, { layer: 'mapnik', format: 'mvt' }, function (err) {
+            assert.ok(err);
+            done();
+        });
+    });
+
     const multipleLayersMapConfig =  {
         version: '1.3.0',
         layers: [

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -500,9 +500,9 @@ function mvtExtractComponents(geometry) {
     });
 }
 
-// Compares (with a tolerance of +- 1) an array of points
+// Compares (with a tolerance of +- 2) an array of points
 function mvtPointArray_cmp(arr1, arr2) {
-    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 1));
+    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 2));
     assert.equal(arr1.length, 0, "Items not found in Mapnik's: " + JSON.stringify(arr1));
 }
 
@@ -652,18 +652,32 @@ function describe_compare_renderer() {
     LAYER_TESTS.forEach(test => {
         it(test.name, function (done) {
 
-            const testClientMapnik = new TestClient(test.mapConfig, { mvt: { usePostGIS: false } });
-            const testClientPg_mvt = new TestClient(test.mapConfig, { mvt: { usePostGIS: true } });
-            const options = { format : 'mvt' };
+            const mapnikOptions = {
+                mvt : {
+                    usePostGIS: true,
+                }
+            };
 
-            testClientMapnik.getTile(test.tile.z, test.tile.x, test.tile.y, options, function (err1, mapnikMVT) {
-                testClientPg_mvt.getTile(test.tile.z, test.tile.x, test.tile.y, options, function (err2, pgMVT) {
-                    if (test.expectedError) {
-                        assert.equal(err1, test.expectedError);
-                        assert.equal(err2, test.expectedError);
-                    } else {
-                        assert.ok(!err1, err1);
-                        assert.ok(!err2, err2);
+            const pgOptions = {
+                mvt : {
+                    usePostGIS: false
+                }
+            };
+
+            const testClientMapnik = new TestClient(test.mapConfig, mapnikOptions);
+            const testClientPg_mvt = new TestClient(test.mapConfig, pgOptions);
+
+            const tileOptions = { format : 'mvt' };
+            const z = test.tile && test.tile.z ? test.tile.z : 0;
+            const x = test.tile && test.tile.x ? test.tile.x : 0;
+            const y = test.tile && test.tile.y ? test.tile.y : 0;
+
+            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
+                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
+                    assert.ok(!err1, err1);
+                    assert.ok(!err2, err2);
+                    assert.deepEqual(mheaders, pheaders);
+                    if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);
                     }
 
@@ -673,14 +687,11 @@ function describe_compare_renderer() {
         });
     });
 
-    const emptyTileError = "Error: Tile does not exist";
 
     const GEOM_TESTS = [
-
         {
             name: 'Null geometry',
-            sql: "SELECT 2 AS cartodb_id, null as the_geom",
-            expectedError : emptyTileError
+            sql: "SELECT 2 AS cartodb_id, null as the_geom"
         },
         {
             name: 'Empty tile',
@@ -688,8 +699,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POINT(-293823 5022065)" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Point',
@@ -731,8 +741,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "LINESTRING(-293823 5022065, -293823 5022065)" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Linestring (repeated points)',
@@ -746,7 +755,8 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "LINESTRING(0 20037508, 0 0, 0 10037508, 0 -10037508, 0 -20037508)" +
-"'::geometry as the_geom"
+"'::geometry as the_geom",
+            tile : { z : 12, x: 12, y: 12 },
         },
         {
             name: 'Linestring (join segments)',
@@ -850,8 +860,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POLYGON((-20037508 20037508, 20037508 -20037508, 20037508 -20037508, 20037508 -20037508, -20037508 20037508))" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Polygon (Duplicates but still valid)',
@@ -901,8 +910,7 @@ function describe_compare_renderer() {
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POLYGON((-20037508 20037508, -20037508 20037508, -20037508 20037508, -20037508 20037508, " +
 "-20037508 20037508, -20037508 20037508))" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Polygon (Self intersection)',
@@ -1006,8 +1014,7 @@ function describe_compare_renderer() {
 "-189856.496116557 4985163.78358654,-189845.714632381 4985154.8544578,-189836.125895049 4985146.44147802," +
 "-189821.934801087 4985133.08649598," +"-189818.054529627 4985129.07872948," +"-189816.829604027 4985127.43227191))" +
 "'::geometry as the_geom, 61374 as cartodb_id",
-            knownIssue : "Mapnik uses a tile size of 256 to simplify (instead of 4096) and a different formula " +
-                         "Should be more similar after https://github.com/CartoDB/Windshaft/issues/641 is done"
+            knownIssue : "Mapnik uses a different formula for simplification to adapt to TWKB grid"
         }
     ];
 
@@ -1041,21 +1048,25 @@ function describe_compare_renderer() {
                 }}}
             };
 
+            const pgOptions = {
+                mvt : {
+                    usePostGIS: true
+                }
+            };
+
             const testClientMapnik = new TestClient(mapConfig, mapnikOptions);
-            const testClientPg_mvt = new TestClient(mapConfig, { mvt: { usePostGIS: true } });
+            const testClientPg_mvt = new TestClient(mapConfig, pgOptions);
             const tileOptions = { format : 'mvt' };
             const z = test.tile && test.tile.z ? test.tile.z : 0;
             const x = test.tile && test.tile.x ? test.tile.x : 0;
             const y = test.tile && test.tile.y ? test.tile.y : 0;
 
-            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT) {
-                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT) {
-                    if (test.expectedError) {
-                        assert.equal(err1, test.expectedError);
-                        assert.equal(err2, test.expectedError);
-                    } else {
-                        assert.ok(!err1, err1);
-                        assert.ok(!err2, err2);
+            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
+                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
+                    assert.ok(!err1, err1);
+                    assert.ok(!err2, err2);
+                    assert.deepEqual(mheaders, pheaders);
+                    if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);
                     }
 

--- a/test/acceptance/zoom-min-max.js
+++ b/test/acceptance/zoom-min-max.js
@@ -213,13 +213,10 @@ describe('minzoom and maxzoom', function() {
 
         const layersValidator = (z, x, y, expectedLayers, done) => {
             return (err, mvtTile) => {
+                assert.ok(!err, err);
                 if (expectedLayers.length === 0) {
-                    assert.ok(err);
-                    assert.equal(err.message, 'Tile does not exist');
                     return done();
                 }
-
-                assert.ok(!err, err);
 
                 var vtile = new mapnik.VectorTile(0, 0, 0);
                 vtile.setData(mvtTile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,19 @@
 # yarn lockfile v1
 
 
-"@carto/mapnik@3.6.2-carto.10":
-  version "3.6.2-carto.10"
-  resolved "https://registry.yarnpkg.com/@carto/mapnik/-/mapnik-3.6.2-carto.10.tgz#a97c951dcdac09d0eb35b3ea71e5eeaa206c1af6"
+"@carto/mapnik@3.6.2-carto.11":
+  version "3.6.2-carto.11"
+  resolved "https://registry.yarnpkg.com/@carto/mapnik/-/mapnik-3.6.2-carto.11.tgz#f2f0bc4d0051080169267c5c729b90c6bc934661"
   dependencies:
-    mapnik-vector-tile cartodb/mapnik-vector-tile#v1.6.1-carto.1
+    mapnik-vector-tile cartodb/mapnik-vector-tile#v1.6.1-carto.2
     nan "2.10.0"
     node-pre-gyp "0.10.0"
-    protozero "1.5.1"
 
-"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb9":
-  version "2.5.1-cdb9"
-  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/5129e43223cb55daed31373c7a36c98eb6178fc1"
+"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb10":
+  version "2.5.1-cdb10"
+  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/118ac7e7f6582ac7be0fc0246ea2afd1a7795a43"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
+    "@carto/mapnik" "3.6.2-carto.11"
     "@mapbox/sphericalmercator" "~1.0.1"
     mapnik-pool "~0.1.3"
 
@@ -23,13 +22,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
 
-abaculus@cartodb/abaculus#2.0.3-cdb10:
-  version "2.0.3-cdb10"
-  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/90d537028bb8af8a35e7a40c46493066dd8a76b3"
+abaculus@cartodb/abaculus#2.0.3-cdb11:
+  version "2.0.3-cdb11"
+  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/b2d4dce48c50fefc5b06f21c6365d82ccf75358d"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
+    "@carto/mapnik" "3.6.2-carto.11"
     d3-queue "^2.0.2"
-    sphericalmercator "1.0.x"
+    sphericalmercator "1.0.5"
 
 abbrev@1:
   version "1.1.1"
@@ -739,6 +738,10 @@ generic-pool@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.3.tgz#780c36f69dfad05a5a045dd37be7adca11a4f6ff"
 
+generic-pool@2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.5.4.tgz#38c6188513e14030948ec6e5cf65523d9779299b"
+
 generic-pool@~2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.1.1.tgz#af04dc2c325cfcb975023fa52bfce9617a7435fd"
@@ -747,7 +750,7 @@ generic-pool@~2.2.0, generic-pool@~2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.2.2.tgz#7a89f491d575b42f9f069a0e8e2c6dbaa3c241be"
 
-generic-pool@~2.4.0, generic-pool@~2.4.1:
+generic-pool@~2.4.1:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.6.tgz#f1b55e572167dba2fe75d5aa91ebb1e9f72642d7"
 
@@ -1236,9 +1239,9 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-mapnik-vector-tile@cartodb/mapnik-vector-tile#v1.6.1-carto.1:
-  version "1.6.1-carto.1"
-  resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/0111f7117946179d62ec7a6eba2f4e9fb355d05e"
+"mapnik-vector-tile@github:cartodb/mapnik-vector-tile#v1.6.1-carto.2":
+  version "1.6.1-carto.2"
+  resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/e7ca5471f9e5de81243e6035e70444321fc0a82f"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1281,13 +1284,13 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mime@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
+
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
-
-mime@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
@@ -1596,7 +1599,7 @@ pg-types@1.*:
     postgres-date "~1.0.0"
     postgres-interval "^1.1.0"
 
-"pg@github:CartoDB/node-postgres#6.4.2-cdb1":
+pg@CartoDB/node-postgres#6.4.2-cdb1:
   version "6.4.2"
   resolved "https://codeload.github.com/CartoDB/node-postgres/tar.gz/449fac1d6da711ffcc6694ae3c89f85244f48bdc"
   dependencies:
@@ -1695,10 +1698,6 @@ progress-stream@~0.5.x:
     single-line-log "~0.3.1"
     speedometer "~0.1.2"
     through2 "~0.2.3"
-
-protozero@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/protozero/-/protozero-1.5.1.tgz#5a27df6fb6e1ed743f510812ae76c082f5b16638"
 
 proxy-addr@~2.0.3:
   version "2.0.3"
@@ -2066,7 +2065,7 @@ speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
 
-sphericalmercator@1.0.5, sphericalmercator@1.0.x, sphericalmercator@~1.0.1, sphericalmercator@~1.0.4:
+sphericalmercator@1.0.5, sphericalmercator@~1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sphericalmercator/-/sphericalmercator-1.0.5.tgz#ddc5a049e360e000d0fad9fc22c4071882584980"
 
@@ -2225,15 +2224,13 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb14:
-  version "0.6.18-cdb14"
-  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/6d06f728833d3e34d1adcd05567b3f4379f547bb"
+tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb15:
+  version "0.6.18-cdb15"
+  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/b6c1404a9e37fc60e545d977081867a86eb42b2b"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
-    generic-pool "~2.4.0"
-    mime "~1.6.0"
-    sphericalmercator "~1.0.4"
-    step "~0.0.5"
+    "@carto/mapnik" "3.6.2-carto.11"
+    generic-pool "2.5.4"
+    mime "2.3.1"
 
 tilelive@5.12.3:
   version "5.12.3"


### PR DESCRIPTION
- Dependency update from mapnik renderer stack:
  - node-mapnik 3.6.2-carto.11: Change the MVT simplification tolerance from tile_width / 256 to tile_width / tile_extent (default 4096).
  - carto/tilelive-bridge 2.5.1-cdb10: Remove error on empty MVT. Now returns an empty buffer and, as before, `x-tilelive-contains-data` set to false.
  - abaculus to 2.0.3-cdb11: Keep up with node-mapnik update.
  - tilelive-mapnik to 0.6.18-cdb15: Rework to remove step, evenEmitter and nextTick.
- MVTs no longer return an error when empty.

~~Pending for this PR:~~
- [x] Fixing tests related to empty MVTs.
- [x] NEWs.
- [x] Performance report for tilelive-mapnik changes impact (empty or low geometry tiles [png, grid.json], with and without metatile).
- [x] Performance report for MVTs after simplification change.

Closes https://github.com/CartoDB/Windshaft/issues/641
Closes https://github.com/CartoDB/Windshaft/issues/633