### PR TITLE
MVT new parameters and update dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@ Announcements:
   - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
   - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
 - MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
-- MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent.
+- MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent in MVTs.
+- MVT renderers (both): Add `vector_simplify_extent` option in MapConfig to configure the simplification process in MVTs.
 
 # Version 4.8.3
 2018-07-19

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Announcements:
 - MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent in MVTs.
 - MVT renderers (both): Add `vector_simplify_extent` option in MapConfig to configure the simplification process in MVTs.
 - pg-mvt renderer: Include the buffer zone in the !bbox! variable.
+- pg-mvt renderer: Fix bug that caused a buffer size of value 0 being ignored.
 
 # Version 4.8.3
 2018-07-19

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Announcements:
 - MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
 - MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent in MVTs.
 - MVT renderers (both): Add `vector_simplify_extent` option in MapConfig to configure the simplification process in MVTs.
+- pg-mvt renderer: Include the buffer zone in the !bbox! variable.
 
 # Version 4.8.3
 2018-07-19

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ Announcements:
   - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
   - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
 - MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
-- MVT renderers (both): Add `vector_layer_extent` option in MapConfig to setup the layer extent.
+- MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent.
 
 # Version 4.8.3
 2018-07-19

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,13 @@
 Announcements:
 - pg-mvt renderer: Match current Mapnik behaviour (Filter column with known types, same default buffer size, accept geom_column ifferent than `the_geom_webmercator`).
 - pg-mvt renderer: Remove undocummented filtering by `layer.options.columns`.
-- MVT tests: Compare outputs from Mapnik and pg-mvt renderers.
+- MVT tests: Compare outputs (tile and headers) from Mapnik and pg-mvt renderers.
+- Update deps:
+  - `@carto/mapnik` to [`3.6.2-carto.11`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto.11/CHANGELOG.carto.md#362-carto11): Geometries in MVTs created with the mapnik renderer will be simplified based on the layer extent instead of a static 256. This has impact in lines and polygon layers, both in results and performance since geometries were being oversimplified.
+  - `@carto/tilelive-bridge` to [`2.5.1-cdb10`](https://github.com/CartoDB/tilelive-bridge/blob/2.5.1-cdb10/CHANGELOG.carto.md#251-cdb10): MVT Mapnik renderer no longers returns error on empty tile, instead it returns an empty buffer.
+  - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
+  - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
+- MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
 
 # Version 4.8.3
 2018-07-19

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Version 4.8.4
+# Version 4.9.0
 2018-XX-XX
 
 Announcements:
@@ -11,6 +11,7 @@ Announcements:
   - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
   - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
 - MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
+- MVT renderers (both): Add `vector_layer_extent` option in MapConfig to setup the layer extent.
 
 # Version 4.8.3
 2018-07-19

--- a/doc/MapConfig-1.8.0.md
+++ b/doc/MapConfig-1.8.0.md
@@ -1,0 +1,359 @@
+# 1. Purpose
+
+This specification describes [MapConfig](MapConfig-specification.md) format version 1.6.0.
+
+
+# 2. File format
+
+Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt).
+
+```javascript
+{
+    // OPTIONAL
+    // Version of this spec to use for validation.
+    // Defaults to "1.0.0".
+    version: "1.7.0",
+
+    // OPTIONAL
+    // default map extent, in map projection
+    // (only webmercator supported at this version)
+    extent: [-20037508.5, -20037508.5, 20037508.5, 20037508.5],
+
+    // OPTIONAL
+    // Spatial reference identifier for the map
+    // Defaults to 3857
+    srid: 3857,
+
+    // OPTIONAL
+    // maxzoom to be renderer. From this zoom tiles will respond 404
+    // default: undefined (infinite)
+    maxzoom: 18,
+
+    // OPTIONAL
+    // minzoom to be renderer. From this zoom tiles will respond 404. Must be less than maxzoom
+    // default: 0
+    minzoom: 3,
+
+    // OPTIONAL
+    // Extra tolerance around the map (in pixels) used to ensure labels crossing tile boundaries are equally rendered
+    // in each tile (e.g. cut in each tile).
+    //
+    // To configure `buffer-size` per tile format:
+    //  - buffersize: {
+    //      'png': 64,
+    //      'grid.json': 64,
+    //      'mvt': 0
+    //    }
+    //
+    // Buffer-size also can be configured through `cartocss`, in these cases the priority to apply the right `buffer-size` is:
+    //  - Raster: cartocss >> map-config >> default
+    //  - Vector: map-config >> default
+    //
+    // default: undefined
+    buffersize: {
+        'png': 64,
+        'grid.json': 64,
+        'mvt': 0
+    },
+
+    // REQUIRED
+    // Array of layers defined in render order
+    // Different kind of layers supported are described below
+    layers: [
+        {
+            // OPTIONAL
+            // string, identifier for the layer
+            // Can be used to access layers by this id
+            // When `undefined` value is provided id will be chosen per layer, usually taking the form `layer{index}`
+            // Defaults to `undefined`
+            id: 'layer-name-id',
+
+            // REQUIRED
+            // string, sets layer type, can take 4 values:
+            //  - 'mapnik'  - rasterized tiles
+            //  - 'cartodb' - an alias for mapnik, for backward compatibility
+            //  - 'torque'  - render vector tiles in torque format (to be linked)
+            //  - 'http'    - load tiles over HTTP
+            //  - 'plain'   - color or background image url
+            type: 'mapnik',
+
+            // REQUIRED
+            // object, set different options for each layer type
+            options: {
+                // See different options by layer type bellow this
+                // NOTE: Options not defined in the different layers will be discarded
+            }
+        }
+    ]
+}
+```
+
+## 2.1 Mapnik layers options
+
+```javascript
+{
+    // REQUIRED
+    // string, SQL to be performed on user database to fetch the data to be rendered.
+    //
+    // It should select at least the columns specified in ``geom_column``,
+    // ``interactivity`` and  ``attributes`` configurations below.
+    //
+    // It can contain substitution tokens `!bbox!`, `!pixel_width!`, `!scale_denominator!`,
+    // and `!pixel_height!`.
+    //
+    sql: 'select * from table',
+
+    // OPTIONAL
+    // string, CartoCSS style to render the tiles
+    //
+    // If this is not present, only vector tiles can be requested for this layer.
+    // For a map to be valid either all the layers or none of them must have CartoCSS style.
+    //
+    // CartoCSS specification depend on layer type:
+    //  Mapnik: https://github.com/mapnik/mapnik-reference/blob/master/2.3.0/reference.json
+    cartocss: '#layer { ... }',
+
+    // OPTIONAL
+    // string, CartoCSS style version of cartocss attribute
+    //
+    // Version semantic is specific to the layer type.
+    //
+    cartocss_version: '2.0.1',
+
+    // OPTIONAL
+    // minzoom to render. From this zoom tiles will not use this layer.
+    // default: 0
+    minzoom: 3,
+
+    // OPTIONAL
+    // maxzoom to render. From this zoom tiles will not use this layer.
+    // default: undefined (infinite)
+    maxzoom: 18,
+
+    // OPTIONAL
+    // name of the column containing the geometry
+    // Defaults to 'the_geom_webmercator'
+    geom_column: 'the_geom_webmercator',
+
+    // OPTIONAL
+    // type of column, can be 'geometry' or 'raster'
+    // Defaults to 'geometry'
+    geom_type: 'geometry',
+
+    // OPTIONAL
+    // raster band, only valid when geom_type = 'raster'.
+    // If 0 or not specified makes rasters being interpreted
+    // as either grayscale (for single bands) or RGB (for 3 bands)
+    // or RGBA (for 4 bands).
+    // Defaults to 0
+    raster_band: 0,
+
+    // OPTIONAL
+    // spatial reference identifier of the geometry column
+    // Defaults to 3857
+    srid: 3857,
+
+    // OPTIONAL
+    // string array, contains tables that SQL uses. It used when affected tables can't be
+    // guessed from SQL (for example, plsql functions are used)
+    affected_tables: [ 'table1', 'schema.table2', '"MixedCase"."Table"' ],
+
+    // OPTIONAL
+    // string array, contains fields renderer inside grid.json
+    // all the params should be exposed by the results of executing the query in sql attribute
+    // NOTE: `interactivity` is incompatible with `geom_type` so it is not possible to create
+    // a layergroup instance with a `raster` layer with geom_type='raster'.
+    interactivity: [ 'field1', 'field2', .. ]
+
+    // OPTIONAL
+    // values returned by attributes service (disabled if no config is given)
+    attributes: {
+        // REQUIRED
+        // used as key value to fetch columns
+        id: 'identifying_column',
+
+        // REQUIRED
+        // string list of columns returned by attributes service
+        columns: ['column1', 'column2']
+    }
+
+    // OPTIONAL
+    // Extent of the layer for MVTs. Must be the same for all layers
+    // Defaults to 4096
+    vector_layer_extent: 4096
+}
+```
+
+## 2.2 Torque layers options
+
+```javascript
+{
+    // REQUIRED
+    // string, SQL to be performed on user database to fetch the data to be rendered.
+    //
+    // It should select at least the columns specified in ``geom_column``,
+    // ``interactivity`` and  ``attributes`` configurations below.
+    //
+    sql: 'select * from table',
+
+    // REQUIRED
+    // string, CartoCSS style to render the tiles
+    //
+    // CartoCSS specification depend on layer type:
+    //  Torque: https://github.com/CartoDB/torque/blob/master/lib/torque/cartocss_reference.js
+    cartocss: '#layer { ... }',
+
+    // REQUIRED
+    // string, CartoCSS style version of cartocss attribute
+    //
+    // Version semantic is specific to the layer type.
+    //
+    cartocss_version: '1.0.0',
+
+    // OPTIONAL
+    // The step to render when requesting a torque.png tile
+    // Defaults to 0
+    step: 0,
+
+    // OPTIONAL
+    // name of the column containing the geometry
+    // Defaults to 'the_geom_webmercator'
+    geom_column: 'the_geom_webmercator',
+
+    // OPTIONAL
+    // spatial reference identifier of the geometry column
+    // Defaults to 3857
+    srid: 3857,
+
+    // OPTIONAL
+    // string array, contains tables that SQL uses. It used when affected tables can't be
+    // guessed from SQL (for example, plsql functions are used)
+    affected_tables: [ 'table1', 'schema.table2', '"MixedCase"."Table"' ],
+
+    // OPTIONAL
+    // values returned by attributes service (disabled if no config is given)
+    attributes: {
+        // REQUIRED
+        // used as key value to fetch columns
+        id: 'identifying_column',
+
+        // REQUIRED
+        // string list of columns returned by attributes service
+        columns: ['column1', 'column2']
+    }
+}
+```
+
+
+## 2.3 Http layers options
+
+```javascript
+{
+    // REQUIRED
+    // {String} end URL to retrieve the tiles from.
+    // Where {z} — zoom level, {x} and {y} — tile coordinates.
+    // And {s} the subdomain, {s} is OPTIONAL. See `subdomains`.
+    //
+    // NOTE: URLs must be included in the configuration whitelist to be valid
+    urlTemplate: "http://{s}.example.com/{z}/{x}/{y}.png",
+
+    // OPTIONAL
+    // {Array<String>} it will be used to retrieve from different subdomains.
+    // It will consistently replace {s} from `urlTemplate`.
+    // Defaults to ['a', 'b', 'c'] when {s} is present in `urlTemplate`, [] otherwise.
+    subdomains: ['a', 'b', 'c'],
+
+    // OPTIONAL
+    // {Boolean} will indicate either the tile is in TMS service format or not
+    // If true, it inverses Y axis numbering for tiles
+    // Defaults to `false`
+    tms: false
+}
+```
+
+## 2.4 Plain layers options
+
+Some notes:
+ - At least one of the options, `color` or `imageUrl`, must be provided.
+ - If both options are provided `color` will be the only one used.
+
+```javascript
+{
+    // OPTIONAL/REQUIRED
+    // {String|Array<Number>}
+    // Defaults to null
+    // Valid colors include:
+    //  - The string may be a CSS color name (e.g. `'blue'`) or a hex color string (e.g. `'#0000ff'`).
+    //  - Integer array with r,g,b values (e.g. `[255,0,0]`)
+    //  - Integer array with r,g,b,a values (e.g. `[255,0,0,128]`)
+    color: 'blue',
+
+    // OPTIONAL/REQUIRED
+    // {String} end URL to retrieve the image from.
+    // Defaults to null
+    imageUrl: 'http://example.com/background.png'
+}
+```
+
+# Extensions
+
+The document may be extended for specific uses.
+For example, Windshaft-CartoDB defines the addition of a "stat_tag" element
+in the config. See https://github.com/CartoDB/Windshaft-cartodb/wiki/MultiLayer-API
+
+Specification for how to name extensions is yet to be defined as of this version
+of MapConfig.
+
+# TODO
+
+ - Allow for each layer to specify the name of the geometry column to use for tiles
+ - Allow to specify layer projection/srid and map projection/srid
+ - Allow to specify quadtree configuration (max extent, mostly)
+ - Link to a document describing "CartoCSS" version (ie: what's required for torque etc.)
+
+# History
+
+## 1.8.0
+
+ - Add support for `vector_layer_extent` in mapnik/cartodb layers.
+
+## 1.7.0
+
+ - Add support for minzoom and maxzoom in mapnik/cartodb layers.
+ - Add support for vector-only configurations (with no CartoCSS)
+
+## 1.6.0
+
+ - Add support for buffer-size configuration
+
+## 1.5.0
+
+ - Add "id" property to layers
+
+## 1.4.0
+
+ - Add support for 'plain' layer type
+
+## 1.3.0
+
+ - Add support for 'http' layer type
+ - Add support in torque layers to specify the step to render when rendering the associated png
+ - Removes interactivity option for mapnik layers with raster geom_type
+ - Removes interactivity option for torque layers. It was never used.
+
+## 1.2.0
+
+ - Add support for 'geom_type' and 'raster_band' in 'mapnik' type layers
+
+## 1.1.0
+
+ - Add support for 'torque' type layers
+ - Add support for 'attributes' specification
+
+## 1.0.1
+
+ - Layer.options.interactivity became an array (from a string)
+
+## 1.0.0
+
+ - Initial version

--- a/doc/MapConfig-1.8.0.md
+++ b/doc/MapConfig-1.8.0.md
@@ -178,9 +178,18 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
     }
 
     // OPTIONAL
-    // Extent of the layer for MVTs. Must be the same for all layers
-    // Defaults to 4096. Range between 1 and (2^31 - 1)
+    // Extent of the layer for MVTs.
+    // Must be the same for all layers
+    // Valid range between 1 and (2^31 - 1)
+    // Defaults to 4096.
     vector_extent: 4096
+
+    // OPTIONAL
+    // Extent used during for the simplification process of the MVTs.
+    // Must be the same for all layers
+    // Valid range between 1 and `vector_extent`. Recommended to be equal to `vector_extent`
+    // Defaults to 256.
+    vector_simplify_extent: 256
 }
 ```
 
@@ -316,6 +325,7 @@ of MapConfig.
 ## 1.8.0
 
  - Add support for `vector_extent` in mapnik/cartodb layers.
+ - Add support for `vector_simplify_extent` in mapnik/cartodb layers.
 
 ## 1.7.0
 

--- a/doc/MapConfig-1.8.0.md
+++ b/doc/MapConfig-1.8.0.md
@@ -188,7 +188,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
     // Extent used during for the simplification process of the MVTs.
     // Must be the same for all layers
     // Valid range between 1 and `vector_extent`. Recommended to be equal to `vector_extent`
-    // Defaults to 256.
+    // Defaults to `vector_extent` if set or 256 if it isn't.
     vector_simplify_extent: 256
 }
 ```

--- a/doc/MapConfig-1.8.0.md
+++ b/doc/MapConfig-1.8.0.md
@@ -179,8 +179,8 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
 
     // OPTIONAL
     // Extent of the layer for MVTs. Must be the same for all layers
-    // Defaults to 4096
-    vector_layer_extent: 4096
+    // Defaults to 4096. Range between 1 and (2^31 - 1)
+    vector_extent: 4096
 }
 ```
 
@@ -315,7 +315,7 @@ of MapConfig.
 
 ## 1.8.0
 
- - Add support for `vector_layer_extent` in mapnik/cartodb layers.
+ - Add support for `vector_extent` in mapnik/cartodb layers.
 
 ## 1.7.0
 

--- a/doc/MapConfig-1.8.0.md
+++ b/doc/MapConfig-1.8.0.md
@@ -12,7 +12,7 @@ Layergroup files use the JSON format as described in [RFC 4627](http://www.ietf.
     // OPTIONAL
     // Version of this spec to use for validation.
     // Defaults to "1.0.0".
-    version: "1.7.0",
+    version: "1.8.0",
 
     // OPTIONAL
     // default map extent, in map projection

--- a/lib/windshaft/backends/map_validator.js
+++ b/lib/windshaft/backends/map_validator.js
@@ -199,10 +199,6 @@ MapValidatorBackend.prototype.validateVectorLayergroup = function (mapConfigProv
     let allLayers; // if layer is undefined then it fetchs all layers
 
     this.tryFetchTileOrGrid(mapConfigProvider, _.clone(params), token, 'mvt', allLayers, (err) => {
-        if (err && err.message === 'Tile does not exist') {
-            return callback(null, true);
-        }
-
         if (err) {
             return callback(err, false);
         }

--- a/lib/windshaft/models/mapconfig.js
+++ b/lib/windshaft/models/mapconfig.js
@@ -14,7 +14,7 @@ function MapConfig(config, datasource) {
     // TODO: inject defaults ?
     this._cfg = config;
 
-    if ( ! semver.satisfies(this.version(), '>= 1.0.0 <= 1.7.0') ) {
+    if ( ! semver.satisfies(this.version(), '>= 1.0.0 <= 1.8.0') ) {
         throw new Error("Unsupported layergroup configuration version " + this.version());
     }
 

--- a/lib/windshaft/models/mapconfig.js
+++ b/lib/windshaft/models/mapconfig.js
@@ -2,7 +2,6 @@ var Crypto = require('crypto');
 var semver = require('semver');
 
 var Datasource = require('./datasource');
-const _ = require('underscore');
 
 // Map configuration object
 
@@ -292,6 +291,9 @@ function create(rawConfig, datasource) {
 
 const DEFAULT_EXTENT = 4096;
 const DEFAULT_SIMPLIFY_EXTENT = 256;
+// Accepted values between 1 and 2^31 -1 (DEFAULT_MAX_EXTENT)
+const DEFAULT_MAX_EXTENT = 2147483647;
+const DEFAULT_MIN_EXTENT = 1;
 
 function checkRange(number, min, max) {
     return (!isNaN(number) && number >= min && number <= max);
@@ -300,83 +302,73 @@ function checkRange(number, min, max) {
 // Checks all layers for a valid `vector_simplify_extent`
 // Makes sure all layers have the same value (or using DEFAULT_EXTENT)
 // Returns undefined if none of the layers have it declared
-function getSimplifyExtent(layers, vector_extent, callback) {
+function getSimplifyExtent(layers, vector_extent) {
     let undef = 0;
-    const extents = _.uniq(layers.map(layer => {
+    const extents = [...new Set(layers.map(layer => {
         if (layer.options.vector_simplify_extent === undefined) {
             undef++;
             return layer.options.vector_extent || DEFAULT_SIMPLIFY_EXTENT;
         }
         return layer.options.vector_simplify_extent;
-    }));
+    }))];
 
     if (extents.length > 1) {
-        return callback(new Error("Multiple simplify extent values in mapConfig (" + extents + ")"));
+        throw new Error("Multiple simplify extent values in mapConfig (" + extents + ")");
     }
 
     if (undef === layers.length) {
-        return callback(null, vector_extent);
+        return vector_extent;
     }
 
     const max_extent = vector_extent || DEFAULT_EXTENT;
 
     // Accepted values between 1 and max_extent
     const simplify_extent = parseInt(extents[0]);
-    if (!checkRange(simplify_extent, 1, max_extent)) {
-        return callback(new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
-                                  "Must be between 1 and vector_extent [" + max_extent + "]"));
+    if (!checkRange(simplify_extent, DEFAULT_MIN_EXTENT, max_extent)) {
+        throw new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
+                        "Must be between 1 and vector_extent [" + max_extent + "]");
     }
 
-    return callback(null, simplify_extent);
+    return simplify_extent;
 }
 
 
 // Checks all layers for a valid `vector_extent`
 // Makes sure all layers have the same value (or using DEFAULT_EXTENT)
 // Returns undefined if none of the layers have it declared
-function getTileExtent(layers, callback) {
+function getTileExtent(layers) {
     let undef = 0;
-    const layer_extents = _.uniq(layers.map(layer => {
+    const layer_extents = [...new Set(layers.map(layer => {
         if (layer.options.vector_extent === undefined) {
             undef++;
             return DEFAULT_EXTENT;
         }
         return layer.options.vector_extent;
-    }));
+    }))];
 
     if (layer_extents.length > 1) {
-        return callback(new Error("Multiple extent values in mapConfig (" + layer_extents + ")"));
+        throw new Error("Multiple extent values in mapConfig (" + layer_extents + ")");
     }
 
     if (undef === layers.length) {
-        return callback(null, undefined);
+        return undefined;
     }
 
-    // Accepted values between 1 and 2^31 -1 (2147483647)
     const extent = parseInt(layer_extents[0]);
-    if (!checkRange(extent, 1, 2147483647)) {
-        return callback(new Error("Invalid vector_extent. Must be between 1 and 2147483647"));
+    if (!checkRange(extent, DEFAULT_MIN_EXTENT, DEFAULT_MAX_EXTENT)) {
+        throw new Error("Invalid vector_extent. Must be between 1 and " + DEFAULT_MAX_EXTENT);
     }
 
-    return callback(null, extent);
+    return extent;
 }
 
-MapConfig.prototype.getMVTExtents = function (callback) {
+// Returns an object with the extents needed for MVTs. Throws on error
+MapConfig.prototype.getMVTExtents = function () {
     const layers = this.getLayers();
+    const extent = getTileExtent(layers);
+    const simplify_extent = getSimplifyExtent(layers, extent);
 
-    getTileExtent(layers, (err, extent) => {
-        if (err) {
-            return callback(err);
-        }
-
-        getSimplifyExtent(layers, extent, (err, simplify_extent) => {
-            if (err) {
-                return callback(err);
-            }
-
-            callback(null, extent || DEFAULT_EXTENT, simplify_extent || DEFAULT_SIMPLIFY_EXTENT);
-        });
-    });
+    return { extent : extent || DEFAULT_EXTENT, simplify_extent : simplify_extent || DEFAULT_SIMPLIFY_EXTENT };
 };
 
 

--- a/lib/windshaft/models/mapconfig.js
+++ b/lib/windshaft/models/mapconfig.js
@@ -2,6 +2,7 @@ var Crypto = require('crypto');
 var semver = require('semver');
 
 var Datasource = require('./datasource');
+const _ = require('underscore');
 
 // Map configuration object
 
@@ -283,6 +284,100 @@ function create(rawConfig, datasource) {
     return new MapConfig(rawConfig, datasource);
 }
 
+
+
+/*****************************************************************************
+ * MVT
+ ****************************************************************************/
+
+const DEFAULT_EXTENT = 4096;
+const DEFAULT_SIMPLIFY_EXTENT = 256;
+
+function checkRange(number, min, max) {
+    return (!isNaN(number) && number >= min && number <= max);
+}
+
+// Checks all layers for a valid `vector_simplify_extent`
+// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
+// Returns undefined if none of the layers have it declared
+function getSimplifyExtent(layers, vector_extent, callback) {
+    let undef = 0;
+    const extents = _.uniq(layers.map(layer => {
+        if (layer.options.vector_simplify_extent === undefined) {
+            undef++;
+            return layer.options.vector_extent || DEFAULT_SIMPLIFY_EXTENT;
+        }
+        return layer.options.vector_simplify_extent;
+    }));
+
+    if (extents.length > 1) {
+        return callback(new Error("Multiple simplify extent values in mapConfig (" + extents + ")"));
+    }
+
+    if (undef === layers.length) {
+        return callback(null, vector_extent);
+    }
+
+    const max_extent = vector_extent || DEFAULT_EXTENT;
+
+    // Accepted values between 1 and max_extent
+    const simplify_extent = parseInt(extents[0]);
+    if (!checkRange(simplify_extent, 1, max_extent)) {
+        return callback(new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
+                                  "Must be between 1 and vector_extent [" + max_extent + "]"));
+    }
+
+    return callback(null, simplify_extent);
+}
+
+
+// Checks all layers for a valid `vector_extent`
+// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
+// Returns undefined if none of the layers have it declared
+function getTileExtent(layers, callback) {
+    let undef = 0;
+    const layer_extents = _.uniq(layers.map(layer => {
+        if (layer.options.vector_extent === undefined) {
+            undef++;
+            return DEFAULT_EXTENT;
+        }
+        return layer.options.vector_extent;
+    }));
+
+    if (layer_extents.length > 1) {
+        return callback(new Error("Multiple extent values in mapConfig (" + layer_extents + ")"));
+    }
+
+    if (undef === layers.length) {
+        return callback(null, undefined);
+    }
+
+    // Accepted values between 1 and 2^31 -1 (2147483647)
+    const extent = parseInt(layer_extents[0]);
+    if (!checkRange(extent, 1, 2147483647)) {
+        return callback(new Error("Invalid vector_extent. Must be between 1 and 2147483647"));
+    }
+
+    return callback(null, extent);
+}
+
+MapConfig.prototype.getMVTExtents = function (callback) {
+    const layers = this.getLayers();
+
+    getTileExtent(layers, (err, extent) => {
+        if (err) {
+            return callback(err);
+        }
+
+        getSimplifyExtent(layers, extent, (err, simplify_extent) => {
+            if (err) {
+                return callback(err);
+            }
+
+            callback(null, extent || DEFAULT_EXTENT, simplify_extent || DEFAULT_SIMPLIFY_EXTENT);
+        });
+    });
+};
 
 
 module.exports = MapConfig;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -411,24 +411,24 @@ function isRasterColumnType(geomColumnType) {
 }
 
 function getMVTOptions(mapConfig, grainstoreOptions) {
-    const e = mapConfig.getMVTExtents();
+    const map_extents = mapConfig.getMVTExtents();
 
     // Make a copy of grainstoreOptions so we can modify it safely
     const newOptions = Object.assign({}, grainstoreOptions);
     newOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
 
-    newOptions.datasource.vector_layer_extent = e.extent;
+    newOptions.datasource.vector_layer_extent = map_extents.extent;
 
     // This function is used to set all the simplify options in Mapnik to work with MVTs
     // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
 
     // TWKB encoding: Adapt the rounding to the simplify extent
-    newOptions.datasource.twkb_rounding_adjustment = Math.log10(e.extent / e.simplify_extent);
+    newOptions.datasource.twkb_rounding_adjustment = Math.log10(map_extents.extent / map_extents.simplify_extent);
 
     // Binary encoding: Disable snapping and simplify geometries up to half pixel
     newOptions.datasource.simplify_geometries = true;
     newOptions.datasource.simplify_snap_ratio = 0;
-    newOptions.datasource.simplify_dp_ratio = 0.5 * e.extent / e.simplify_extent;
+    newOptions.datasource.simplify_dp_ratio = 0.5 * map_extents.extent / map_extents.simplify_extent;
     newOptions.datasource.simplify_dp_preserve = true;
 
     return newOptions;

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -117,13 +117,6 @@ function MapnikFactory(options) {
         variables: {}
     });
 
-    // Create a shallow copy of options.grainstore and modify the datasource if needed
-    const gr_opts = Object.assign({}, options.grainstore);
-    if (options.vector_layer_extent && gr_opts.datasource) {
-        gr_opts.datasource =  Object.assign({vector_layer_extent : options.vector_layer_extent }, gr_opts.datasource);
-    }
-    this._mmlStore = new grainstore.MMLStore(gr_opts);
-
     this.tile_scale_factors = this._mapnik_opts.scale_factors.reduce(function(previousValue, currentValue) {
         previousValue[currentValue] = DEFAULT_TILE_SIZE * currentValue;
         return previousValue;
@@ -198,10 +191,15 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
     step(
         function initBuilder() {
             var mmlBuilderOptions = {};
+            var grainstoreOptions = self._options.grainstore;
             if (format === 'png32') {
                 mmlBuilderOptions.mapnik_tile_format = 'png';
+            } else if (format === FORMAT_MVT) {
+                grainstoreOptions = Object.assign({}, grainstoreOptions);
+                setLayerExtent(grainstoreOptions, mmlBuilderConfig, self._options);
             }
 
+            self._mmlStore = new grainstore.MMLStore(grainstoreOptions);
             self._mmlStore.mml_builder(params, mmlBuilderOptions).toXML(this);
         },
         function loadMapnik(err, xml) {
@@ -284,7 +282,8 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         datasource_extend: [],
         extra_ds_opts: [],
         gcols: [],
-        'cache-features': rendererOptions.params['cache-features']
+        'cache-features': rendererOptions.params['cache-features'],
+        layer_extents: []
     };
 
     var layerFilter = rendererOptions.layer;
@@ -329,6 +328,8 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         }
         options.datasource_extend.push(mapConfig.getLayerDatasource(layerIndex));
         options.extra_ds_opts.push( extra_opt );
+
+        options.layer_extents.push(lyropt.vector_layer_extent);
 
         return options;
     }, options);
@@ -406,4 +407,23 @@ function prepareQuery(userSql, geomColumnName, geomColumnType, options) {
 
 function isRasterColumnType(geomColumnType) {
     return geomColumnType === COLUMN_TYPE_RASTER;
+}
+
+function setLayerExtent(grainstoreOptions, mmlOptions, options) {
+    const extents = _.uniq(mmlOptions.layer_extents);
+    const def = extents.indexOf(undefined);
+    if (def !== -1) {
+        extents[def] = 4096;
+    }
+    const extentsDefined = _.uniq(extents);
+
+    if (extentsDefined.length > 1) {
+        throw new Error("Multiple extent values in mapConfig (" + extents + ")");
+    }
+
+    const extent = (def !== -1 && extentsDefined.length === 1) ? options.vector_layer_extent : extents[0];
+
+    if (extent && grainstoreOptions.datasource) {
+        grainstoreOptions.datasource =  Object.assign({vector_layer_extent : extent }, grainstoreOptions.datasource);
+    }
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -22,17 +22,14 @@ var DEFAULT_TILE_SIZE = 256;
 var FORMAT_MVT = 'mvt';
 
 function MapnikFactory(options) {
-    options.grainstore = options.grainstore || {};
 
     this.supportedFormats = {
         'png': true,
         'png32': true,
-        'grid.json': true
+        'grid.json': true,
+        'mvt': true
     };
 
-    this.supportedFormats[FORMAT_MVT] = true;
-
-    this._mmlStore = new grainstore.MMLStore(options.grainstore);
     this._options = options;
 
     // Set default mapnik options
@@ -118,8 +115,14 @@ function MapnikFactory(options) {
 
         //INTERNAL: Render time variables
         variables: {}
-
     });
+
+    // Create a shallow copy of options.grainstore and modify the datasource if needed
+    const gr_opts = Object.assign({}, options.grainstore);
+    if (options.vector_layer_extent && gr_opts.datasource) {
+        gr_opts.datasource =  Object.assign({vector_layer_extent : options.vector_layer_extent }, gr_opts.datasource);
+    }
+    this._mmlStore = new grainstore.MMLStore(gr_opts);
 
     this.tile_scale_factors = this._mapnik_opts.scale_factors.reduce(function(previousValue, currentValue) {
         previousValue[currentValue] = DEFAULT_TILE_SIZE * currentValue;
@@ -164,7 +167,7 @@ MapnikFactory.prototype.defineExpectedParams = function (params) {
 MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, callback) {
     var self = this;
 
-    if (mapConfig.isVectorOnlyMapConfig() && format !== 'mvt') {
+    if (mapConfig.isVectorOnlyMapConfig() && format !== FORMAT_MVT) {
         const error = new Error(`Unsupported format: 'cartocss' option is missing for ${format}`);
         error.http_status = 400;
         error.type = 'tile';

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -449,7 +449,7 @@ function setSimplifyExtent(grainstoreOptions, mmlOptions) {
 
     const def = extents.indexOf(undefined);
     if (def !== -1) {
-        extents[def] = DEFAULT_SIMPLIFY_EXTENT;
+        extents[def] = grainstoreOptions.datasource.vector_layer_extent || DEFAULT_SIMPLIFY_EXTENT;
     }
     const extentsDefined = _.uniq(extents);
 

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -196,7 +196,7 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
                 mmlBuilderOptions.mapnik_tile_format = 'png';
             } else if (format === FORMAT_MVT) {
                 grainstoreOptions = Object.assign({}, grainstoreOptions);
-                setLayerExtent(grainstoreOptions, mmlBuilderConfig, self._options);
+                setLayerExtent(grainstoreOptions, mmlBuilderConfig);
             }
 
             self._mmlStore = new grainstore.MMLStore(grainstoreOptions);
@@ -409,7 +409,7 @@ function isRasterColumnType(geomColumnType) {
     return geomColumnType === COLUMN_TYPE_RASTER;
 }
 
-function setLayerExtent(grainstoreOptions, mmlOptions, options) {
+function setLayerExtent(grainstoreOptions, mmlOptions) {
     const extents = _.uniq(mmlOptions.layer_extents);
     const def = extents.indexOf(undefined);
     if (def !== -1) {
@@ -421,9 +421,7 @@ function setLayerExtent(grainstoreOptions, mmlOptions, options) {
         throw new Error("Multiple extent values in mapConfig (" + extents + ")");
     }
 
-    const extent = (def !== -1 && extentsDefined.length === 1) ? options.vector_layer_extent : extents[0];
-
-    if (extent && grainstoreOptions.datasource) {
-        grainstoreOptions.datasource =  Object.assign({vector_layer_extent : extent }, grainstoreOptions.datasource);
+    if (!(def !== -1 && extentsDefined.length === 1)) {
+        grainstoreOptions.datasource = Object.assign({vector_layer_extent : extents[0] }, grainstoreOptions.datasource);
     }
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -19,8 +19,6 @@ var COLUMN_TYPE_DEFAULT = COLUMN_TYPE_GEOMETRY;
 
 var DEFAULT_TILE_SIZE = 256;
 
-const DEFAULT_EXTENT = 4096;
-const DEFAULT_SIMPLIFY_EXTENT = 256;
 
 var FORMAT_MVT = 'mvt';
 
@@ -193,21 +191,19 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
 
     step(
         function initBuilder() {
-            var mmlBuilderOptions = {};
-            var grainstoreOptions = self._options.grainstore;
+            const mmlBuilderOptions = {};
             if (format === 'png32') {
                 mmlBuilderOptions.mapnik_tile_format = 'png';
-            } else if (format === FORMAT_MVT) {
-                // Make a copy of grainstoreOptions so we can modify it safely
-                grainstoreOptions = Object.assign({}, grainstoreOptions);
-                grainstoreOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
-
-                setLayerExtent(grainstoreOptions, mmlBuilderConfig);
-                setSimplifyExtent(grainstoreOptions, mmlBuilderConfig);
             }
 
-            self._mmlStore = new grainstore.MMLStore(grainstoreOptions);
-            self._mmlStore.mml_builder(params, mmlBuilderOptions).toXML(this);
+            getMVTOptions(mapConfig, format, self._options.grainstore, (err, newOptions) => {
+                if (err) {
+                    return callback(err);
+                }
+
+                self._mmlStore = new grainstore.MMLStore(newOptions);
+                self._mmlStore.mml_builder(params, mmlBuilderOptions).toXML(this);
+            });
         },
         function loadMapnik(err, xml) {
             assert.ifError(err);
@@ -289,9 +285,7 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         datasource_extend: [],
         extra_ds_opts: [],
         gcols: [],
-        'cache-features': rendererOptions.params['cache-features'],
-        layer_extents: [],
-        simplify_extents: []
+        'cache-features': rendererOptions.params['cache-features']
     };
 
     var layerFilter = rendererOptions.layer;
@@ -337,8 +331,6 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         options.datasource_extend.push(mapConfig.getLayerDatasource(layerIndex));
         options.extra_ds_opts.push( extra_opt );
 
-        options.layer_extents.push(lyropt.vector_extent);
-        options.simplify_extents.push(lyropt.vector_simplify_extent);
 
         return options;
     }, options);
@@ -418,64 +410,33 @@ function isRasterColumnType(geomColumnType) {
     return geomColumnType === COLUMN_TYPE_RASTER;
 }
 
-function checkRange(number, min, max) {
-    return (!isNaN(number) && number >= min && number <= max);
-}
+function getMVTOptions(mapConfig, format, grainstoreOptions, callback) {
+    if (format !== FORMAT_MVT) {
+        return callback(null, grainstoreOptions);
+    }
 
-function setLayerExtent(grainstoreOptions, mmlOptions) {
-    const extents = _.uniq(mmlOptions.layer_extents);
-    const def = extents.indexOf(undefined);
-    if (def !== -1) {
-        if (extents.length === 1) {
-            return;
+    mapConfig.getMVTExtents((err, extent, simplify_extent) => {
+        if (err) {
+            return callback(err);
         }
-        extents[def] = DEFAULT_EXTENT;
-    }
+        // Make a copy of grainstoreOptions so we can modify it safely
+        const newOptions = Object.assign({}, grainstoreOptions);
+        newOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
 
-    const extentsDefined = _.uniq(extents);
+        newOptions.datasource.vector_layer_extent = extent;
 
-    if (extentsDefined.length > 1) {
-        throw new Error("Multiple extent values in mapConfig (" + extents + ")");
-    }
+        // This function is used to set all the simplify options in Mapnik to work with MVTs
+        // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
 
-    // Accepted values between 1 and 2^31 -1 (2147483647)
-    const extent = parseInt(extentsDefined[0], 10);
-    if (!checkRange(extent, 1, 2147483647)) {
-        throw new Error("Invalid vector_extent. Must be between 1 and 2147483647");
-    }
-    grainstoreOptions.datasource.vector_layer_extent = extents[0];
-}
+        // TWKB encoding: Adapt the rounding to the simplify extent
+        newOptions.datasource.twkb_rounding_adjustment = Math.log10(extent / simplify_extent);
 
-function setSimplifyExtent(grainstoreOptions, mmlOptions) {
-    const extents = _.uniq(mmlOptions.simplify_extents);
+        // Binary encoding: Disable snapping and simplify geometries up to half pixel
+        newOptions.datasource.simplify_geometries = true;
+        newOptions.datasource.simplify_snap_ratio = 0;
+        newOptions.datasource.simplify_dp_ratio = 0.5 * extent / simplify_extent;
+        newOptions.datasource.simplify_dp_preserve = true;
 
-    const def = extents.indexOf(undefined);
-    if (def !== -1) {
-        extents[def] = grainstoreOptions.datasource.vector_layer_extent || DEFAULT_SIMPLIFY_EXTENT;
-    }
-    const extentsDefined = _.uniq(extents);
-
-    if (extentsDefined.length > 1) {
-        throw new Error("Multiple simplify extent values in mapConfig (" + extents + ")");
-    }
-
-    // Accepted values between 1 and vector_extent
-    const vector_extent = grainstoreOptions.datasource.vector_layer_extent || DEFAULT_EXTENT;
-    const simplify = parseInt(extentsDefined[0], 10);
-    if (!checkRange(simplify, 1, vector_extent)) {
-        throw new Error("Invalid vector_simplify_extent (" + simplify + "). " +
-                        "Must be between 1 and vector_extent [" + vector_extent + "]");
-    }
-
-    // This function is used to set all the simplify options in Mapnik to work with MVTs
-    // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
-
-    // TWKB encoding: Adapt the rounding to the simplify extent
-    grainstoreOptions.datasource.twkb_rounding_adjustment = Math.log10(vector_extent / simplify);
-
-    // Binary encoding: Disable snapping and simplify geometries up to half pixel
-    grainstoreOptions.datasource.simplify_geometries = true;
-    grainstoreOptions.datasource.simplify_snap_ratio = 0;
-    grainstoreOptions.datasource.simplify_dp_ratio = 0.5 * vector_extent / simplify;
-    grainstoreOptions.datasource.simplify_dp_preserve = true;
+        callback(null, newOptions);
+    });
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -329,7 +329,7 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         options.datasource_extend.push(mapConfig.getLayerDatasource(layerIndex));
         options.extra_ds_opts.push( extra_opt );
 
-        options.layer_extents.push(lyropt.vector_layer_extent);
+        options.layer_extents.push(lyropt.vector_extent);
 
         return options;
     }, options);
@@ -421,7 +421,12 @@ function setLayerExtent(grainstoreOptions, mmlOptions) {
         throw new Error("Multiple extent values in mapConfig (" + extents + ")");
     }
 
-    if (!(def !== -1 && extentsDefined.length === 1)) {
-        grainstoreOptions.datasource = Object.assign({vector_layer_extent : extents[0] }, grainstoreOptions.datasource);
+    // Accepted values between 1 and 2^31 -1 (2147483647)
+    const extent = parseInt(extentsDefined[0], 10);
+    if ((isNaN(extent)) || (extent < 1) || (extent > 2147483647)) {
+        throw new Error("Invalid vector_extent. Must be between 1 and 2147483647");
     }
+
+    grainstoreOptions.datasource = Object.assign({vector_layer_extent : extents[0] }, grainstoreOptions.datasource);
+
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -189,6 +189,8 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
         return callback(err);
     }
 
+    const isMvt = format === FORMAT_MVT;
+
     step(
         function initBuilder() {
             const mmlBuilderOptions = {};
@@ -196,14 +198,14 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
                 mmlBuilderOptions.mapnik_tile_format = 'png';
             }
 
-            getMVTOptions(mapConfig, format, self._options.grainstore, (err, newOptions) => {
-                if (err) {
-                    return callback(err);
-                }
+            // getMVTOptions migth throw <<<<<
+            const grainstoreOptions = isMvt ?
+                    getMVTOptions(mapConfig, self._options.grainstore) :
+                    self._options.grainstore;
 
-                self._mmlStore = new grainstore.MMLStore(newOptions);
-                self._mmlStore.mml_builder(params, mmlBuilderOptions).toXML(this);
-            });
+            self._mmlStore = new grainstore.MMLStore(grainstoreOptions);
+            self._mmlStore.mml_builder(params, mmlBuilderOptions).toXML(this);
+
         },
         function loadMapnik(err, xml) {
             assert.ifError(err);
@@ -221,8 +223,6 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
                 metrics: options.params.metrics,
                 variables: variables
             };
-
-            var isMvt = format === FORMAT_MVT;
 
             // build full document to pass to tilelive
             var uri = {
@@ -410,33 +410,26 @@ function isRasterColumnType(geomColumnType) {
     return geomColumnType === COLUMN_TYPE_RASTER;
 }
 
-function getMVTOptions(mapConfig, format, grainstoreOptions, callback) {
-    if (format !== FORMAT_MVT) {
-        return callback(null, grainstoreOptions);
-    }
+function getMVTOptions(mapConfig, grainstoreOptions) {
+    const e = mapConfig.getMVTExtents();
 
-    mapConfig.getMVTExtents((err, extent, simplify_extent) => {
-        if (err) {
-            return callback(err);
-        }
-        // Make a copy of grainstoreOptions so we can modify it safely
-        const newOptions = Object.assign({}, grainstoreOptions);
-        newOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
+    // Make a copy of grainstoreOptions so we can modify it safely
+    const newOptions = Object.assign({}, grainstoreOptions);
+    newOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
 
-        newOptions.datasource.vector_layer_extent = extent;
+    newOptions.datasource.vector_layer_extent = e.extent;
 
-        // This function is used to set all the simplify options in Mapnik to work with MVTs
-        // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
+    // This function is used to set all the simplify options in Mapnik to work with MVTs
+    // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
 
-        // TWKB encoding: Adapt the rounding to the simplify extent
-        newOptions.datasource.twkb_rounding_adjustment = Math.log10(extent / simplify_extent);
+    // TWKB encoding: Adapt the rounding to the simplify extent
+    newOptions.datasource.twkb_rounding_adjustment = Math.log10(e.extent / e.simplify_extent);
 
-        // Binary encoding: Disable snapping and simplify geometries up to half pixel
-        newOptions.datasource.simplify_geometries = true;
-        newOptions.datasource.simplify_snap_ratio = 0;
-        newOptions.datasource.simplify_dp_ratio = 0.5 * extent / simplify_extent;
-        newOptions.datasource.simplify_dp_preserve = true;
+    // Binary encoding: Disable snapping and simplify geometries up to half pixel
+    newOptions.datasource.simplify_geometries = true;
+    newOptions.datasource.simplify_snap_ratio = 0;
+    newOptions.datasource.simplify_dp_ratio = 0.5 * e.extent / e.simplify_extent;
+    newOptions.datasource.simplify_dp_preserve = true;
 
-        callback(null, newOptions);
-    });
+    return newOptions;
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -197,6 +197,7 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
             } else if (format === FORMAT_MVT) {
                 grainstoreOptions = Object.assign({}, grainstoreOptions);
                 setLayerExtent(grainstoreOptions, mmlBuilderConfig);
+                setSimplifyExtent(grainstoreOptions, mmlBuilderConfig);
             }
 
             self._mmlStore = new grainstore.MMLStore(grainstoreOptions);
@@ -283,7 +284,8 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         extra_ds_opts: [],
         gcols: [],
         'cache-features': rendererOptions.params['cache-features'],
-        layer_extents: []
+        layer_extents: [],
+        simplify_extents: []
     };
 
     var layerFilter = rendererOptions.layer;
@@ -330,6 +332,7 @@ MapnikFactory.prototype.mapConfigToMMLBuilderConfig = function(mapConfig, queryR
         options.extra_ds_opts.push( extra_opt );
 
         options.layer_extents.push(lyropt.vector_extent);
+        options.simplify_extents.push(lyropt.vector_simplify_extent);
 
         return options;
     }, options);
@@ -428,5 +431,38 @@ function setLayerExtent(grainstoreOptions, mmlOptions) {
     }
 
     grainstoreOptions.datasource = Object.assign({vector_layer_extent : extents[0] }, grainstoreOptions.datasource);
+}
 
+function setSimplifyExtent(grainstoreOptions, mmlOptions) {
+    const extents = _.uniq(mmlOptions.simplify_extents);
+
+    const def = extents.indexOf(undefined);
+    if (def !== -1) {
+        extents[def] = 256;
+    }
+    const extentsDefined = _.uniq(extents);
+
+    if (extentsDefined.length > 1) {
+        throw new Error("Multiple simplify extent values in mapConfig (" + extents + ")");
+    }
+
+    // Accepted values between 1 and vector_extent
+    const vector_extent = grainstoreOptions.datasource.vector_layer_extent;
+    const simplify = parseInt(extentsDefined[0], 10);
+    if ((isNaN(simplify)) || (simplify < 1) || (simplify > vector_extent)) {
+        throw new Error("Invalid vector_simplify_extent (" + simplify + "). " +
+                        "Must be between 1 and vector_extent [" + vector_extent + "]");
+    }
+
+    // This function is used to set all the simplify options in Mapnik to work with MVTs
+    // so it's tied to `plugins/input/postgis/postgis_datasource.cpp`
+
+    // TWKB encoding: Adapt the rounding to the simplify extent
+    grainstoreOptions.datasource.twkb_rounding_adjustment = Math.log10(vector_extent / simplify);
+
+    // Binary encoding: Disable snapping and simplify geometries up to half pixel
+    grainstoreOptions.datasource.simplify_geometries = true;
+    grainstoreOptions.datasource.simplify_snap_ratio = 0;
+    grainstoreOptions.datasource.simplify_dp_ratio = 0.5 * vector_extent / simplify;
+    grainstoreOptions.datasource.simplify_dp_preserve = true;
 }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -19,6 +19,9 @@ var COLUMN_TYPE_DEFAULT = COLUMN_TYPE_GEOMETRY;
 
 var DEFAULT_TILE_SIZE = 256;
 
+const DEFAULT_EXTENT = 4096;
+const DEFAULT_SIMPLIFY_EXTENT = 256;
+
 var FORMAT_MVT = 'mvt';
 
 function MapnikFactory(options) {
@@ -412,12 +415,20 @@ function isRasterColumnType(geomColumnType) {
     return geomColumnType === COLUMN_TYPE_RASTER;
 }
 
+function checkRange(number, min, max) {
+    return (!isNaN(number) && number >= min && number <= max);
+}
+
 function setLayerExtent(grainstoreOptions, mmlOptions) {
     const extents = _.uniq(mmlOptions.layer_extents);
     const def = extents.indexOf(undefined);
     if (def !== -1) {
-        extents[def] = 4096;
+        if (extents.length === 1) {
+            return;
+        }
+        extents[def] = DEFAULT_EXTENT;
     }
+
     const extentsDefined = _.uniq(extents);
 
     if (extentsDefined.length > 1) {
@@ -426,7 +437,7 @@ function setLayerExtent(grainstoreOptions, mmlOptions) {
 
     // Accepted values between 1 and 2^31 -1 (2147483647)
     const extent = parseInt(extentsDefined[0], 10);
-    if ((isNaN(extent)) || (extent < 1) || (extent > 2147483647)) {
+    if (!checkRange(extent, 1, 2147483647)) {
         throw new Error("Invalid vector_extent. Must be between 1 and 2147483647");
     }
 
@@ -438,7 +449,7 @@ function setSimplifyExtent(grainstoreOptions, mmlOptions) {
 
     const def = extents.indexOf(undefined);
     if (def !== -1) {
-        extents[def] = 256;
+        extents[def] = DEFAULT_SIMPLIFY_EXTENT;
     }
     const extentsDefined = _.uniq(extents);
 
@@ -447,9 +458,9 @@ function setSimplifyExtent(grainstoreOptions, mmlOptions) {
     }
 
     // Accepted values between 1 and vector_extent
-    const vector_extent = grainstoreOptions.datasource.vector_layer_extent;
+    const vector_extent = grainstoreOptions.datasource.vector_layer_extent || DEFAULT_EXTENT;
     const simplify = parseInt(extentsDefined[0], 10);
-    if ((isNaN(simplify)) || (simplify < 1) || (simplify > vector_extent)) {
+    if (!checkRange(simplify, 1, vector_extent)) {
         throw new Error("Invalid vector_simplify_extent (" + simplify + "). " +
                         "Must be between 1 and vector_extent [" + vector_extent + "]");
     }

--- a/lib/windshaft/renderers/mapnik/factory.js
+++ b/lib/windshaft/renderers/mapnik/factory.js
@@ -198,7 +198,10 @@ MapnikFactory.prototype.getRenderer = function (mapConfig, format, options, call
             if (format === 'png32') {
                 mmlBuilderOptions.mapnik_tile_format = 'png';
             } else if (format === FORMAT_MVT) {
+                // Make a copy of grainstoreOptions so we can modify it safely
                 grainstoreOptions = Object.assign({}, grainstoreOptions);
+                grainstoreOptions.datasource = Object.assign({}, grainstoreOptions.datasource);
+
                 setLayerExtent(grainstoreOptions, mmlBuilderConfig);
                 setSimplifyExtent(grainstoreOptions, mmlBuilderConfig);
             }
@@ -440,8 +443,7 @@ function setLayerExtent(grainstoreOptions, mmlOptions) {
     if (!checkRange(extent, 1, 2147483647)) {
         throw new Error("Invalid vector_extent. Must be between 1 and 2147483647");
     }
-
-    grainstoreOptions.datasource = Object.assign({vector_layer_extent : extents[0] }, grainstoreOptions.datasource);
+    grainstoreOptions.datasource.vector_layer_extent = extents[0];
 }
 
 function setSimplifyExtent(grainstoreOptions, mmlOptions) {

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -171,9 +171,7 @@ PgMvtFactory.prototype = {
                 return callback(err);
             }
 
-            if (extent) {
-                this.options.vector_layer_extent = extent;
-            }
+            this.options.vector_layer_extent = extent || 4096;
 
             const columnNamesPromises = layers.map(layer => {
                 return getLayerColumns(psql, layer);

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -94,8 +94,26 @@ function getLayerColumns(psql, layer) {
     });
 }
 
+
+function getTileExtent(layers, callback) {
+    let undef = 0;
+    const layer_extents = _.uniq(layers.map(layer => {
+        if (layer.options.vector_layer_extent === undefined) {
+            undef++;
+        }
+        return layer.options.vector_layer_extent || 4096;
+    }));
+
+    if (layer_extents.length > 1) {
+        return callback(new Error("Multiple extent values in mapConfig (" + layer_extents + ")"));
+    }
+
+    return callback(null, undef !== layers.length ? layer_extents[0] : undefined);
+}
+
 module.exports = PgMvtFactory;
 const NAME = 'pg-mvt';
+const MVT_FORMAT = 'mvt';
 module.exports.NAME = NAME;
 
 PgMvtFactory.prototype = {
@@ -103,14 +121,14 @@ PgMvtFactory.prototype = {
     name: NAME,
 
     /// API: tile formats this module is able to render
-    supported_formats: ['mvt'],
+    supported_formats: [MVT_FORMAT],
 
     getName: function () {
         return this.name;
     },
 
     supportsFormat: function (format) {
-        return format === 'mvt';
+        return format === MVT_FORMAT;
     },
 
     getAdaptor: function (renderer, format, onTileErrorStrategy) {
@@ -118,7 +136,7 @@ PgMvtFactory.prototype = {
     },
 
     getRenderer: function (mapConfig, format, options, callback) {
-        if (mapConfig.isVectorOnlyMapConfig() && format !== 'mvt') {
+        if (mapConfig.isVectorOnlyMapConfig() && format !== MVT_FORMAT) {
             const error = new Error(`Unsupported format: 'cartocss' option is missing for ${format}`);
             error.http_status = 400;
             error.type = 'tile';
@@ -144,15 +162,25 @@ PgMvtFactory.prototype = {
         _.extend(dbParams, mapConfig.getLayerDatasource(options.layer));
         const psql = new PSQL(dbParams, this.options.dbPoolParams);
 
-        if (Number.isFinite(mapConfig.getBufferSize('mvt'))) {
-            this.options.bufferSize = mapConfig.getBufferSize('mvt');
+        if (Number.isFinite(mapConfig.getBufferSize(MVT_FORMAT))) {
+            this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
         }
 
-        const columnNamesPromises = layers.map(layer => {
-            return getLayerColumns(psql, layer);
+        getTileExtent(layers, (err, extent) => {
+            if (err) {
+                return callback(err);
+            }
+
+            if (extent) {
+                this.options.vector_layer_extent = extent;
+            }
+
+            const columnNamesPromises = layers.map(layer => {
+                return getLayerColumns(psql, layer);
+            });
+            Promise.all(columnNamesPromises)
+            .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
+            .catch(err => callback(err));
         });
-        Promise.all(columnNamesPromises)
-        .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
-        .catch(err => callback(err));
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -233,10 +233,8 @@ PgMvtFactory.prototype = {
 
                 this.options.vector_simplify_extent = simplify_extent || DEFAULT_SIMPLIFY_EXTENT;
 
-                const columnNamesPromises = layers.map(layer => {
-                    return getLayerColumns(psql, layer);
-                });
-                Promise.all(columnNamesPromises)
+                const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
+                Promise.all(columnNamePromises)
                 .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
                 .catch(err => callback(err));
             });

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -149,18 +149,19 @@ PgMvtFactory.prototype = {
             this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
         }
 
-        mapConfig.getMVTExtents((err, extent, simplify_extent) => {
-            if (err) {
-                return callback(err);
-            }
+        let e = {};
+        try {
+            e = mapConfig.getMVTExtents();
+        } catch(err) {
+            return callback(err);
+        }
 
-            this.options.vector_extent = extent;
-            this.options.vector_simplify_extent = simplify_extent;
+        this.options.vector_extent = e.extent;
+        this.options.vector_simplify_extent = e.simplify_extent;
 
-            const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
-            Promise.all(columnNamePromises)
-            .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
-            .catch(err => callback(err));
-        });
+        const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
+        Promise.all(columnNamePromises)
+        .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
+        .catch(err => callback(err));
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -98,17 +98,28 @@ function getLayerColumns(psql, layer) {
 function getTileExtent(layers, callback) {
     let undef = 0;
     const layer_extents = _.uniq(layers.map(layer => {
-        if (layer.options.vector_layer_extent === undefined) {
+        if (layer.options.vector_extent === undefined) {
             undef++;
+            return 4096;
         }
-        return layer.options.vector_layer_extent || 4096;
+        return layer.options.vector_extent;
     }));
 
     if (layer_extents.length > 1) {
         return callback(new Error("Multiple extent values in mapConfig (" + layer_extents + ")"));
     }
 
-    return callback(null, undef !== layers.length ? layer_extents[0] : undefined);
+    if (undef === layers.length) {
+        return callback(null, undefined);
+    }
+
+    // Accepted values between 1 and 2^31 -1 (2147483647)
+    const extent = parseInt(layer_extents[0]);
+    if ((isNaN(extent)) || (extent < 1) || (extent > 2147483647)) {
+        return callback(new Error("Invalid vector_extent. Must be between 1 and 2147483647"));
+    }
+
+    return callback(null, extent);
 }
 
 module.exports = PgMvtFactory;
@@ -171,7 +182,7 @@ PgMvtFactory.prototype = {
                 return callback(err);
             }
 
-            this.options.vector_layer_extent = extent || 4096;
+            this.options.vector_extent = extent || 4096;
 
             const columnNamesPromises = layers.map(layer => {
                 return getLayerColumns(psql, layer);

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -8,6 +8,9 @@ const Renderer = require('./renderer');
 const BaseAdaptor = require('../base_adaptor');
 const SubstitutionTokens = require('../../utils/substitution_tokens');
 
+const DEFAULT_EXTENT = 4096;
+const DEFAULT_SIMPLIFY_EXTENT = 256;
+
 /**
  * API: initializes the renderer, it should be called once
  *
@@ -94,12 +97,19 @@ function getLayerColumns(psql, layer) {
     });
 }
 
+function checkRange(number, min, max) {
+    return (!isNaN(number) && number >= min && number <= max);
+}
+
+// Checks all layers for a valid `vector_extent`
+// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
+// Returns undefined if none of the layers have it declared
 function getTileExtent(layers, callback) {
     let undef = 0;
     const layer_extents = _.uniq(layers.map(layer => {
         if (layer.options.vector_extent === undefined) {
             undef++;
-            return 4096;
+            return DEFAULT_EXTENT;
         }
         return layer.options.vector_extent;
     }));
@@ -114,19 +124,22 @@ function getTileExtent(layers, callback) {
 
     // Accepted values between 1 and 2^31 -1 (2147483647)
     const extent = parseInt(layer_extents[0]);
-    if ((isNaN(extent)) || (extent < 1) || (extent > 2147483647)) {
+    if (!checkRange(extent, 1, 2147483647)) {
         return callback(new Error("Invalid vector_extent. Must be between 1 and 2147483647"));
     }
 
     return callback(null, extent);
 }
 
+// Checks all layers for a valid `vector_simplify_extent`
+// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
+// Returns undefined if none of the layers have it declared
 function getSimplifyExtent(layers, vector_extent, callback) {
     let undef = 0;
     const extents = _.uniq(layers.map(layer => {
         if (layer.options.vector_simplify_extent === undefined) {
             undef++;
-            return 256;
+            return DEFAULT_SIMPLIFY_EXTENT;
         }
         return layer.options.vector_simplify_extent;
     }));
@@ -136,14 +149,16 @@ function getSimplifyExtent(layers, vector_extent, callback) {
     }
 
     if (undef === layers.length) {
-        return callback(null, undefined);
+        return callback(null, vector_extent);
     }
+
+    const max_extent = vector_extent || DEFAULT_EXTENT;
 
     // Accepted values between 1 and max_extent
     const simplify_extent = parseInt(extents[0]);
-    if ((isNaN(simplify_extent)) || (simplify_extent < 1) || (simplify_extent > vector_extent)) {
+    if (!checkRange(simplify_extent, 1, max_extent)) {
         return callback(new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
-                                  "Must be between 1 and vector_extent [" + vector_extent + "]"));
+                                  "Must be between 1 and vector_extent [" + max_extent + "]"));
     }
 
     return callback(null, simplify_extent);
@@ -209,14 +224,14 @@ PgMvtFactory.prototype = {
                 return callback(err);
             }
 
-            this.options.vector_extent = extent || 4096;
+            this.options.vector_extent = extent || DEFAULT_EXTENT;
 
-            getSimplifyExtent(layers, this.options.vector_extent, (err, simplify_extent) => {
+            getSimplifyExtent(layers, extent, (err, simplify_extent) => {
                 if (err) {
                     return callback(err);
                 }
 
-                this.options.vector_simplify_extent = simplify_extent;
+                this.options.vector_simplify_extent = simplify_extent || DEFAULT_SIMPLIFY_EXTENT;
 
                 const columnNamesPromises = layers.map(layer => {
                     return getLayerColumns(psql, layer);

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -94,7 +94,6 @@ function getLayerColumns(psql, layer) {
     });
 }
 
-
 function getTileExtent(layers, callback) {
     let undef = 0;
     const layer_extents = _.uniq(layers.map(layer => {
@@ -120,6 +119,34 @@ function getTileExtent(layers, callback) {
     }
 
     return callback(null, extent);
+}
+
+function getSimplifyExtent(layers, vector_extent, callback) {
+    let undef = 0;
+    const extents = _.uniq(layers.map(layer => {
+        if (layer.options.vector_simplify_extent === undefined) {
+            undef++;
+            return 256;
+        }
+        return layer.options.vector_simplify_extent;
+    }));
+
+    if (extents.length > 1) {
+        return callback(new Error("Multiple simplify extent values in mapConfig (" + extents + ")"));
+    }
+
+    if (undef === layers.length) {
+        return callback(null, undefined);
+    }
+
+    // Accepted values between 1 and max_extent
+    const simplify_extent = parseInt(extents[0]);
+    if ((isNaN(simplify_extent)) || (simplify_extent < 1) || (simplify_extent > vector_extent)) {
+        return callback(new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
+                                  "Must be between 1 and vector_extent [" + vector_extent + "]"));
+    }
+
+    return callback(null, simplify_extent);
 }
 
 module.exports = PgMvtFactory;
@@ -184,12 +211,20 @@ PgMvtFactory.prototype = {
 
             this.options.vector_extent = extent || 4096;
 
-            const columnNamesPromises = layers.map(layer => {
-                return getLayerColumns(psql, layer);
+            getSimplifyExtent(layers, this.options.vector_extent, (err, simplify_extent) => {
+                if (err) {
+                    return callback(err);
+                }
+
+                this.options.vector_simplify_extent = simplify_extent;
+
+                const columnNamesPromises = layers.map(layer => {
+                    return getLayerColumns(psql, layer);
+                });
+                Promise.all(columnNamesPromises)
+                .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
+                .catch(err => callback(err));
             });
-            Promise.all(columnNamesPromises)
-            .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
-            .catch(err => callback(err));
         });
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -149,15 +149,15 @@ PgMvtFactory.prototype = {
             this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
         }
 
-        let e = {};
+        let map_extents = {};
         try {
-            e = mapConfig.getMVTExtents();
+            map_extents = mapConfig.getMVTExtents();
         } catch(err) {
             return callback(err);
         }
 
-        this.options.vector_extent = e.extent;
-        this.options.vector_simplify_extent = e.simplify_extent;
+        this.options.vector_extent = map_extents.extent;
+        this.options.vector_simplify_extent = map_extents.simplify_extent;
 
         const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
         Promise.all(columnNamePromises)

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -8,9 +8,6 @@ const Renderer = require('./renderer');
 const BaseAdaptor = require('../base_adaptor');
 const SubstitutionTokens = require('../../utils/substitution_tokens');
 
-const DEFAULT_EXTENT = 4096;
-const DEFAULT_SIMPLIFY_EXTENT = 256;
-
 /**
  * API: initializes the renderer, it should be called once
  *
@@ -97,73 +94,6 @@ function getLayerColumns(psql, layer) {
     });
 }
 
-function checkRange(number, min, max) {
-    return (!isNaN(number) && number >= min && number <= max);
-}
-
-// Checks all layers for a valid `vector_extent`
-// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
-// Returns undefined if none of the layers have it declared
-function getTileExtent(layers, callback) {
-    let undef = 0;
-    const layer_extents = _.uniq(layers.map(layer => {
-        if (layer.options.vector_extent === undefined) {
-            undef++;
-            return DEFAULT_EXTENT;
-        }
-        return layer.options.vector_extent;
-    }));
-
-    if (layer_extents.length > 1) {
-        return callback(new Error("Multiple extent values in mapConfig (" + layer_extents + ")"));
-    }
-
-    if (undef === layers.length) {
-        return callback(null, undefined);
-    }
-
-    // Accepted values between 1 and 2^31 -1 (2147483647)
-    const extent = parseInt(layer_extents[0]);
-    if (!checkRange(extent, 1, 2147483647)) {
-        return callback(new Error("Invalid vector_extent. Must be between 1 and 2147483647"));
-    }
-
-    return callback(null, extent);
-}
-
-// Checks all layers for a valid `vector_simplify_extent`
-// Makes sure all layers have the same value (or using DEFAULT_EXTENT)
-// Returns undefined if none of the layers have it declared
-function getSimplifyExtent(layers, vector_extent, callback) {
-    let undef = 0;
-    const extents = _.uniq(layers.map(layer => {
-        if (layer.options.vector_simplify_extent === undefined) {
-            undef++;
-            return layer.options.vector_extent || DEFAULT_SIMPLIFY_EXTENT;
-        }
-        return layer.options.vector_simplify_extent;
-    }));
-
-    if (extents.length > 1) {
-        return callback(new Error("Multiple simplify extent values in mapConfig (" + extents + ")"));
-    }
-
-    if (undef === layers.length) {
-        return callback(null, vector_extent);
-    }
-
-    const max_extent = vector_extent || DEFAULT_EXTENT;
-
-    // Accepted values between 1 and max_extent
-    const simplify_extent = parseInt(extents[0]);
-    if (!checkRange(simplify_extent, 1, max_extent)) {
-        return callback(new Error("Invalid vector_simplify_extent (" + simplify_extent + "). " +
-                                  "Must be between 1 and vector_extent [" + max_extent + "]"));
-    }
-
-    return callback(null, simplify_extent);
-}
-
 module.exports = PgMvtFactory;
 const NAME = 'pg-mvt';
 const MVT_FORMAT = 'mvt';
@@ -219,25 +149,18 @@ PgMvtFactory.prototype = {
             this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
         }
 
-        getTileExtent(layers, (err, extent) => {
+        mapConfig.getMVTExtents((err, extent, simplify_extent) => {
             if (err) {
                 return callback(err);
             }
 
-            this.options.vector_extent = extent || DEFAULT_EXTENT;
+            this.options.vector_extent = extent;
+            this.options.vector_simplify_extent = simplify_extent;
 
-            getSimplifyExtent(layers, extent, (err, simplify_extent) => {
-                if (err) {
-                    return callback(err);
-                }
-
-                this.options.vector_simplify_extent = simplify_extent || DEFAULT_SIMPLIFY_EXTENT;
-
-                const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
-                Promise.all(columnNamePromises)
-                .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
-                .catch(err => callback(err));
-            });
+            const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
+            Promise.all(columnNamePromises)
+            .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
+            .catch(err => callback(err));
         });
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -139,7 +139,7 @@ function getSimplifyExtent(layers, vector_extent, callback) {
     const extents = _.uniq(layers.map(layer => {
         if (layer.options.vector_simplify_extent === undefined) {
             undef++;
-            return DEFAULT_SIMPLIFY_EXTENT;
+            return layer.options.vector_extent || DEFAULT_SIMPLIFY_EXTENT;
         }
         return layer.options.vector_simplify_extent;
     }));

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -46,6 +46,11 @@ function getLayerColumns(psql, layer) {
         if (layer._mvtColumns) {
             return resolve();
         }
+
+        if (!layer.options.sql) {
+            return reject("Missing sql for layer");
+        }
+
         const layerSQL = setDefaultTokens(layer.options.sql, 0, 0, 0);
         const limitedQuery = `SELECT * FROM (${layerSQL}) __windshaft_mvt_schema LIMIT 0;`;
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -25,6 +25,7 @@ function extractMVT(data) {
 /// A renderer for a given MapConfig layer
 ///
 module.exports = class PostgresVectorRenderer {
+
     constructor (layers, psql, attrs, options) {
         options = options || {};
 
@@ -35,8 +36,8 @@ module.exports = class PostgresVectorRenderer {
         this.tile_size = 256;
         this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
         this.buffer_size = options.bufferSize || 64; // Same as Mapnik::bufferSize
-        this.vector_extent = options.vector_extent || 4096; // Same as Mapnik::vector_extent
-        this.vector_simplify_extent = options.vector_simplify_extent || 256; // Same as Mapnik::vector_simplify_extent
+        this.vector_extent = options.vector_extent;
+        this.vector_simplify_extent = options.vector_simplify_extent;
         this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);
     }
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -45,11 +45,10 @@ module.exports = class PostgresVectorRenderer {
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        const emptyTileMsg = 'Tile does not exist';
         const subqueries = this._getLayerQueries({ z, x, y });
 
         if (subqueries.length === 0) {
-            return callback(new Error(emptyTileMsg));
+            return callback(null, new Buffer(0));
         }
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
@@ -67,14 +66,13 @@ module.exports = class PostgresVectorRenderer {
             }
 
             const mvt = extractMVT(data);
-            if (!mvt) {
-                return callback(new Error(emptyTileMsg));
-            }
-
-            const headers = { 'Content-Type': 'application/x-protobuf' };
+            const headers = {
+                'Content-Type': 'application/x-protobuf',
+                'x-tilelive-contains-data' : mvt ? true : false
+            };
             const stats = timer.getTimes();
 
-            return callback(null, mvt, headers, stats);
+            return callback(null, mvt || new Buffer(0), headers, stats);
         });
     }
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -33,7 +33,7 @@ module.exports = class PostgresVectorRenderer {
 
         this.tile_size = 256;
         this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
-        this.buffer_size = options.bufferSize || 64; // Same as Mapnik::bufferSize
+        this.buffer_size = options.hasOwnProperty('bufferSize') ? options.bufferSize : 64; // Same as Mapnik::bufferSize
         this.vector_extent = options.vector_extent;
         this.vector_simplify_extent = options.vector_simplify_extent;
         this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -26,9 +26,7 @@ function extractMVT(data) {
 ///
 module.exports = class PostgresVectorRenderer {
 
-    constructor (layers, psql, attrs, options) {
-        options = options || {};
-
+    constructor (layers, psql, attrs, options = {}) {
         this.psql = psql;
         this.attrs = attrs;
         this.layers = layers;

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -35,8 +35,8 @@ module.exports = class PostgresVectorRenderer {
         this.tile_size = options.tileSize || 256;
         this.tile_max_geosize = options.maxGeosize || 40075017; // earth circumference in webmercator 3857
         this.buffer_size = options.bufferSize || 64; // Same as Mapnik::bufferSize
-        this.vector_layer_extent = options.vector_layer_extent || 4096; // Same as Mapnik::vector_layer_extent
-        this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_layer_extent / this.tile_size);
+        this.vector_extent = options.vector_extent || 4096; // Same as Mapnik::vector_extent
+        this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);
     }
 
     /// API: renders a tile with the Renderer configuration
@@ -95,7 +95,7 @@ module.exports = class PostgresVectorRenderer {
         return `ST_AsMVTGeom(
                     ${geomColumn},
                     CDB_XYZ_Extent(${x},${y},${z}),
-                    ${this.vector_layer_extent},
+                    ${this.vector_extent},
                     ${this.subpixelBufferSize},
                     true
                 ) as the_geom_webmercator`;
@@ -119,7 +119,7 @@ module.exports = class PostgresVectorRenderer {
         const geomColumn = layer.options.geom_column || 'the_geom_webmercator';
         const columnList = !columns ? '' : `, "${columns.join('", "')}"`;
 
-        return `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_layer_extent}, 'the_geom_webmercator')
+        return `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_extent}, 'the_geom_webmercator')
                 FROM (
                     SELECT ${geometryColumn}${columnList}
                     FROM (${query}) AS cdbq

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -45,11 +45,16 @@ module.exports = class PostgresVectorRenderer {
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        const subqueries = this._getLayerQueries({ z, x, y });
+        const headers = {
+            'Content-Type': 'application/x-protobuf',
+            'x-tilelive-contains-data' : false
+        };
 
+        const subqueries = this._getLayerQueries({ z, x, y });
         if (subqueries.length === 0) {
-            return callback(null, new Buffer(0));
+            return callback(null, new Buffer(0), headers);
         }
+
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
         const timer = new Timer();
@@ -66,10 +71,9 @@ module.exports = class PostgresVectorRenderer {
             }
 
             const mvt = extractMVT(data);
-            const headers = {
-                'Content-Type': 'application/x-protobuf',
-                'x-tilelive-contains-data' : mvt ? true : false
-            };
+            if (mvt) {
+                headers['x-tilelive-contains-data'] = true;
+            }
             const stats = timer.getTimes();
 
             return callback(null, mvt || new Buffer(0), headers, stats);

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -32,10 +32,11 @@ module.exports = class PostgresVectorRenderer {
         this.attrs = attrs;
         this.layers = layers;
 
-        this.tile_size = options.tileSize || 256;
-        this.tile_max_geosize = options.maxGeosize || 40075017; // earth circumference in webmercator 3857
+        this.tile_size = 256;
+        this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
         this.buffer_size = options.bufferSize || 64; // Same as Mapnik::bufferSize
         this.vector_extent = options.vector_extent || 4096; // Same as Mapnik::vector_extent
+        this.vector_simplify_extent = options.vector_simplify_extent || 256; // Same as Mapnik::vector_simplify_extent
         this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);
     }
 
@@ -90,8 +91,12 @@ module.exports = class PostgresVectorRenderer {
         });
     }
 
-    _geomColumn (layer, { z, x, y }) {
-        const geomColumn = layer.options.geom_column || 'the_geom_webmercator';
+    _geomColumn (layer, { z = 0, x = 0, y = 0 }) {
+        let geomColumn = layer.options.geom_column || 'the_geom_webmercator';
+        if (this.vector_extent !== this.vector_simplify_extent) {
+            const tol = (this.tile_max_geosize / Math.pow(2, z)) / (this.vector_simplify_extent * 2);
+            geomColumn = `ST_Simplify(ST_RemoveRepeatedPoints(${geomColumn}, ${tol}), ${tol}, true)`;
+        }
         return `ST_AsMVTGeom(
                     ${geomColumn},
                     CDB_XYZ_Extent(${x},${y},${z}),

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -35,8 +35,8 @@ module.exports = class PostgresVectorRenderer {
         this.tile_size = options.tileSize || 256;
         this.tile_max_geosize = options.maxGeosize || 40075017; // earth circumference in webmercator 3857
         this.buffer_size = options.bufferSize || 64; // Same as Mapnik::bufferSize
-        this.mvt_extent = options.mvt_extent || 4096;
-        this.subpixelBufferSize = Math.round(this.buffer_size * this.mvt_extent / this.tile_size);
+        this.vector_layer_extent = options.vector_layer_extent || 4096; // Same as Mapnik::vector_layer_extent
+        this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_layer_extent / this.tile_size);
     }
 
     /// API: renders a tile with the Renderer configuration
@@ -95,7 +95,7 @@ module.exports = class PostgresVectorRenderer {
         return `ST_AsMVTGeom(
                     ${geomColumn},
                     CDB_XYZ_Extent(${x},${y},${z}),
-                    ${this.mvt_extent},
+                    ${this.vector_layer_extent},
                     ${this.subpixelBufferSize},
                     true
                 ) as the_geom_webmercator`;
@@ -119,7 +119,7 @@ module.exports = class PostgresVectorRenderer {
         const geomColumn = layer.options.geom_column || 'the_geom_webmercator';
         const columnList = !columns ? '' : `, "${columns.join('", "')}"`;
 
-        return `SELECT ST_AsMVT(geom, '${layerId}')
+        return `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_layer_extent}, 'the_geom_webmercator')
                 FROM (
                     SELECT ${geometryColumn}${columnList}
                     FROM (${query}) AS cdbq
@@ -129,7 +129,7 @@ module.exports = class PostgresVectorRenderer {
                             CDB_XYZ_Extent(${x},${y},${z}),
                             CDB_XYZ_Resolution(${z}) * ${Math.round(256 * this.buffer_size / this.tile_size)}
                         )
-                ) AS geom
+                ) AS geometries
         `;
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -85,8 +85,7 @@ module.exports = class PostgresVectorRenderer {
                           .filter(layer => shouldUseLayer(layer, z))
                           .map(layer => {
             const geomColumn = this._geomColumn(layer, { z, x, y });
-            const query = this._replaceTokens(layer.options.sql, { z, x, y });
-            return this._vectorLayerQuery(layer, geomColumn, layer._mvtColumns, query, { z, x, y });
+            return this._vectorLayerQuery(layer, geomColumn, layer._mvtColumns, layer.options.sql, { z, x, y });
         });
     }
 
@@ -107,7 +106,10 @@ module.exports = class PostgresVectorRenderer {
 
     _replaceTokens (sql, { z = 0, x = 0, y = 0 }) {
         return SubstitutionTokens.replace(sql, {
-            bbox: `CDB_XYZ_Extent(${x},${y},${z})`,
+            bbox: `ST_Expand(
+                            CDB_XYZ_Extent(${x},${y},${z}),
+                            CDB_XYZ_Resolution(${z}) * ${Math.round(256 * this.buffer_size / this.tile_size)}
+                        )`,
             // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
             scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric *${256 / this.tile_size / 0.00028})`,
             pixel_width: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
@@ -123,17 +125,13 @@ module.exports = class PostgresVectorRenderer {
         const geomColumn = layer.options.geom_column || 'the_geom_webmercator';
         const columnList = !columns ? '' : `, "${columns.join('", "')}"`;
 
-        return `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_extent}, 'the_geom_webmercator')
+        return this._replaceTokens(
+                `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_extent}, 'the_geom_webmercator')
                 FROM (
                     SELECT ${geometryColumn}${columnList}
                     FROM (${query}) AS cdbq
-                    WHERE
-                        ${geomColumn} &&
-                        ST_Expand(
-                            CDB_XYZ_Extent(${x},${y},${z}),
-                            CDB_XYZ_Resolution(${z}) * ${Math.round(256 * this.buffer_size / this.tile_size)}
-                        )
+                    WHERE ${geomColumn} && !bbox!
                 ) AS geometries
-        `;
+                `, { z, x, y });
     }
 };

--- a/lib/windshaft/renderers/renderer_factory.js
+++ b/lib/windshaft/renderers/renderer_factory.js
@@ -17,7 +17,7 @@ function RendererFactory(opts) {
     opts.mvt = opts.mvt || {};
     this.opts = opts;
 
-    this.mapnikRendererFactory = new MapnikRenderer.factory(opts.mapnik);
+    this.mapnikRendererFactory = new MapnikRenderer.factory(Object.assign(opts.mapnik, opts.mvt));
     this.blendRendererFactory = new BlendRenderer.factory(this);
 
     var availableFactories = [

--- a/lib/windshaft/renderers/renderer_factory.js
+++ b/lib/windshaft/renderers/renderer_factory.js
@@ -17,7 +17,7 @@ function RendererFactory(opts) {
     opts.mvt = opts.mvt || {};
     this.opts = opts;
 
-    this.mapnikRendererFactory = new MapnikRenderer.factory(Object.assign(opts.mapnik, opts.mvt));
+    this.mapnikRendererFactory = new MapnikRenderer.factory(opts.mapnik);
     this.blendRendererFactory = new BlendRenderer.factory(this);
 
     var availableFactories = [

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
         "Daniel Garcia Aubert <dgaubert@carto.com>"
     ],
     "dependencies": {
-        "@carto/mapnik": "3.6.2-carto.10",
-        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb9",
-        "abaculus": "cartodb/abaculus#2.0.3-cdb10",
+        "@carto/mapnik": "3.6.2-carto.11",
+        "@carto/tilelive-bridge": "cartodb/tilelive-bridge#2.5.1-cdb10",
+        "abaculus": "cartodb/abaculus#2.0.3-cdb11",
         "canvas": "cartodb/node-canvas#1.6.2-cdb2",
         "carto": "cartodb/carto#0.15.1-cdb3",
         "cartodb-psql": "0.11.0",
@@ -37,7 +37,7 @@
         "sphericalmercator": "1.0.5",
         "step": "1.0.0",
         "tilelive": "5.12.3",
-        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb14",
+        "tilelive-mapnik": "cartodb/tilelive-mapnik#0.6.18-cdb15",
         "torque.js": "2.16.2",
         "underscore": "1.6.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "4.8.4",
+    "version": "4.9.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [

--- a/test/acceptance/attributes.js
+++ b/test/acceptance/attributes.js
@@ -54,7 +54,7 @@ describe('attributes', function() {
 
         var testClient = new TestClient(createMapConfig());
         testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(attributes, { n: 6 });
             done();
         });
@@ -67,7 +67,7 @@ describe('attributes', function() {
                   "json_agg(row_to_json((SELECT r FROM (SELECT 1 as d, 'Samuel' as name) r),true)) as data";
         var testClient = new TestClient(createMapConfig(sql, 'i', ['n', 'data']));
         testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(attributes, { n: 6, data: [ { d: 1, name: 'Samuel' } ] });
             done();
         });
@@ -77,7 +77,7 @@ describe('attributes', function() {
 
         var testClient = new TestClient(createMapConfig());
         testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 2, function (err, attributes) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(attributes, { n: 6 });
             done();
         });
@@ -94,7 +94,7 @@ describe('attributes', function() {
 
         var testClient = new TestClient(createMapConfig(sql, 'i', ['n', 'data']));
         testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(attributes, { n: 6, data: [ { d: 1, name: 'Samuel' } ] });
             done();
         });
@@ -172,7 +172,7 @@ describe('attributes', function() {
 
         var testClient = new TestClient(createMapConfig(substitutionTokenSql, 'i', Object.keys(expectedAttributes)));
         testClient.getFeatureAttributes(ATTRIBUTES_LAYER, 1, function (err, attributes) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.deepEqual(attributes, expectedAttributes);
             done();
         });

--- a/test/acceptance/blend.js
+++ b/test/acceptance/blend.js
@@ -84,7 +84,7 @@ describe('blend png renderer', function() {
             var testClient = new TestClient(plainTorqueMapConfig(testScenario.plainColor));
             testClient.getTile(tileRequest.z, tileRequest.x, tileRequest.y, function(err, tile) {
                 assert.imageEqualsFile(tile, blendPngFixture(zxy), IMAGE_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     done();
                 });
             });

--- a/test/acceptance/blend_filtering.js
+++ b/test/acceptance/blend_filtering.js
@@ -143,7 +143,7 @@ describe('blend layer filtering', function() {
         it('should filter on ' + layerFilter + '/1/0/0.png', function (done) {
             testClient.getTile(1, 0, 0, {layer: layerFilter}, function(err, tile) {
                 assert.imageEqualsFile(tile, blendPngFixture(filteredLayers), IMG_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     done();
                 });
             });

--- a/test/acceptance/blend_http_fallback.js
+++ b/test/acceptance/blend_http_fallback.js
@@ -99,7 +99,7 @@ describe('blend http fallback', function() {
         it('should fallback on http error while blending layers ' + layerFilter + '/1/0/0.png', function (done) {
             testClient.getTile(1, 0, 0, {layer: layerFilter}, function(err, tile) {
                 assert.imageEqualsFile(tile, blendPngFixture(filteredLayers), IMG_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
                     done();
                 });
             });

--- a/test/acceptance/layer-filtering-regressions.js
+++ b/test/acceptance/layer-filtering-regressions.js
@@ -45,7 +45,7 @@ describe('layer filtering regressions', () => {
         it(`should work with mapnik layer ids: ${scenario.layers}`, function(done) {
             const testClient = new TestClient(mapConfig);
             testClient.getTile(0, 0, 0, { layer: scenario.layers, format: 'mvt'}, function (err, mvtTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
 
                 const vtile = new mapnik.VectorTile(0, 0, 0);
                 vtile.setData(mvtTile);

--- a/test/acceptance/limits.js
+++ b/test/acceptance/limits.js
@@ -48,7 +48,7 @@ describe('render limits', function() {
     it('uses onTileErrorStrategy to handle error and modify response', function(done) {
         var testClient = new TestClient(slowQueryMapConfig, OVERRIDE_OPTIONS, onTileErrorStrategyFallback);
         testClient.createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             done();

--- a/test/acceptance/maknik_render_time_variables.js
+++ b/test/acceptance/maknik_render_time_variables.js
@@ -49,11 +49,11 @@ describe('layer filtering', function() {
 
             var testClient = new TestClient(mapConfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile) {
-                assert.ok(!err);
+                assert.ifError(err);
                 var filepath = getAssertFilepath(color, limit);
 
                 assert.imageEqualsFile(tile, filepath, IMG_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     done();
                 });
             });
@@ -71,11 +71,11 @@ describe('layer filtering', function() {
 
             var testClient = new TestClient(mapConfig);
             testClient.getTile(0, 0, 0, overriddenOptions, function(err, tile) {
-                assert.ok(!err);
+                assert.ifError(err);
                 var filepath = getAssertFilepath(color, limit);
 
                 assert.imageEqualsFile(tile, filepath, IMG_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     done();
                 });
             });

--- a/test/acceptance/mapnik_meta_layergroup.js
+++ b/test/acceptance/mapnik_meta_layergroup.js
@@ -60,7 +60,7 @@ describe('Create mapnik layergroup', function() {
         });
 
         testClient.createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
             assert.equal(layergroup.metadata.layers[0].type, 'mapnik');
             assert.equal(layergroup.metadata.layers[1].id, typeLayerId('http', 0));
@@ -79,7 +79,7 @@ describe('Create mapnik layergroup', function() {
         });
 
         testClient.createLayergroup(function (err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, typeLayerId('http', 0));
             assert.equal(layergroup.metadata.layers[0].type, 'http');
             assert.ok(!layergroup.metadata.layers[0].meta.cartocss);
@@ -99,7 +99,7 @@ describe('Create mapnik layergroup', function() {
         });
 
         testClient.createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
             done();
         });

--- a/test/acceptance/markers_symbolizer_caches_config.js
+++ b/test/acceptance/markers_symbolizer_caches_config.js
@@ -38,7 +38,7 @@ describe('markers_symbolizer_caches config', function() {
         var testClient = new TestClient(MAPCONFIG, options);
 
         testClient.getTile(0, 0, 0, {format: FORMAT}, function(err, tile, img, headers, stats) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Miss'), true);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Ignored'), false);
             done();
@@ -59,7 +59,7 @@ describe('markers_symbolizer_caches config', function() {
 
         var testClient = new TestClient(MAPCONFIG, options);
         testClient.getTile(0, 0, 0, {format: FORMAT}, function(err, tile, img, headers, stats) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Miss'), false);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Ignored'), true);
             done();
@@ -80,7 +80,7 @@ describe('markers_symbolizer_caches config', function() {
 
         var testClient = new TestClient(MAPCONFIG, options);
         testClient.getTile(0, 0, 0, {format: FORMAT}, function(err, tile, img, headers, stats) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Miss'), true);
             assert.equal(stats.hasOwnProperty('Mk_Agg_PMS_ImageCache_Ignored'), false);
             done();

--- a/test/acceptance/metrics.js
+++ b/test/acceptance/metrics.js
@@ -43,7 +43,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } }, strat);
             testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert(!stats.hasOwnProperty('Mapnik'));
                 assert(stats.hasOwnProperty('Mk_Setup'));
                 assert(stats.hasOwnProperty('Mk_Render'));
@@ -79,7 +79,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : false } } }, strat);
             testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert(!stats.hasOwnProperty('Mapnik'));
                 assert(!stats.hasOwnProperty('Mk_Setup'));
                 assert(!stats.hasOwnProperty('Mk_Render'));
@@ -116,7 +116,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } }, strat);
             testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert(!stats.hasOwnProperty('Mapnik'));
                 assert(stats.hasOwnProperty('Mk_Setup'));
                 assert(!stats.hasOwnProperty('Mk_Render'));
@@ -149,7 +149,7 @@ describe('metrics', function() {
 
         var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metatile: 2, metrics : true } } });
         testClient.getTile(1, 1, 1, {format: 'png'}, function(err, tile, img, headers, stats) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert(!stats.hasOwnProperty('Mapnik'));
             assert(stats.hasOwnProperty('Mk_Setup'));
             assert(stats.hasOwnProperty('Mk_Render'));
@@ -232,7 +232,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 3);
                 assert.equal(stats.Mk_Features_cnt_MultiPoint, 2);
                 assert.equal(stats.Mk_Features_cnt_LineString, 2);
@@ -273,7 +273,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Unknown, 4);
                 done();
             });
@@ -319,7 +319,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 10);
                 assert.equal(stats.Mk_Agg_PMS_AttrCache_Miss, 1);
                 done();
@@ -347,7 +347,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 5);
                 assert.equal(stats.Mk_Agg_PMS_AttrCache_Miss, 1);
                 done();
@@ -375,7 +375,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 10);
                 assert.equal(stats.Mk_Agg_PMS_AttrCache_Miss, 10);
                 done();
@@ -403,7 +403,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 10);
                 assert.equal(stats.Mk_Agg_PMS_AttrCache_Miss, 1);
                 assert.equal(stats.Mk_Agg_PMS_EllipseCache_Miss, 1);
@@ -436,7 +436,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_LineString, 2);
                 assert(!stats.hasOwnProperty('Mk_Agg_PMS_EllipseCache_Miss'));
                 done();
@@ -480,7 +480,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, overriddenOptions);
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 10);
                 assert(!stats.hasOwnProperty('Mk_Agg_PMS_EllipseCache_Miss'));
                 resourcesServer.close(done);
@@ -511,7 +511,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 10);
                 assert.equal(stats.Mk_Agg_PMS_ImageCache_Miss, 1);
                 done();
@@ -541,7 +541,7 @@ describe('metrics', function() {
 
             var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
             testClient.getTile(0, 0, 0, {format: "png"}, function(err, tile, img, headers, stats) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.equal(stats.Mk_Features_cnt_Point, 3);
                 assert.equal(stats.Mk_Agg_PMS_ImageCache_Ignored, 3);
                 done();
@@ -600,7 +600,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PBuildS') || stats.hasOwnProperty('Mk_Grid_PBuildS'));
                         done();
                     });
@@ -628,7 +628,7 @@ describe('metrics', function() {
 
                         var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                         testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                            assert.ok(!err);
+                            assert.ifError(err);
                             assert(stats.hasOwnProperty('Mk_Agg_PDotS'));
                             done();
                         });
@@ -657,7 +657,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PGroupS') || stats.hasOwnProperty('Mk_Grid_PGroupS'));
                         done();
                     });
@@ -688,7 +688,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PLinePatternS') ||
                                stats.hasOwnProperty('Mk_Grid_PLinePatternS'));
                         done();
@@ -720,7 +720,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PLineS') || stats.hasOwnProperty('Mk_Grid_PLineS'));
                         done();
                     });
@@ -747,7 +747,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PMarkerS') || stats.hasOwnProperty('Mk_Grid_PMarkerS'));
                         done();
                     });
@@ -774,7 +774,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PPointS') || stats.hasOwnProperty('Mk_Grid_PPointS'));
                         done();
                     });
@@ -809,7 +809,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PPolygonPatternS') ||
                                stats.hasOwnProperty('Mk_Grid_PPolygonPatternS'));
                         done();
@@ -845,7 +845,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PPolygonS') || stats.hasOwnProperty('Mk_Grid_PPolygonS'));
                         done();
                     });
@@ -873,7 +873,7 @@ describe('metrics', function() {
 
                         var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                         testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                            assert.ok(!err);
+                            assert.ifError(err);
                             assert(stats.hasOwnProperty('Mk_Agg_PRasterS'));
                             done();
                         });
@@ -902,7 +902,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PShieldS') || stats.hasOwnProperty('Mk_Grid_PShieldS'));
                         done();
                     });
@@ -930,7 +930,7 @@ describe('metrics', function() {
 
                     var testClient = new TestClient(mapconfig, { mapnik : { mapnik : { metrics : true } } });
                     testClient.getTile(0, 0, 0, {format: format}, function(err, tile, img, headers, stats) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         assert(stats.hasOwnProperty('Mk_Agg_PTextS') || stats.hasOwnProperty('Mk_Grid_PTextS'));
                         done();
                     });

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -107,7 +107,7 @@ describe('multilayer', function() {
     it("layergroup with 2 layers, create layergroup", function(done) {
         var testClient = new TestClient(layergroup);
         testClient.createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             assert.equal(layergroup.metadata.layers.length, 2);
@@ -145,7 +145,7 @@ describe('multilayer', function() {
     it("layergroup with 3 mixed layers, mapnik png torque and attributes", function(done) {
         var testClient = new TestClient(layergroupWith3Layers);
         testClient.getTile(0, 0, 0, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.imageEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer1.png',
                 IMAGE_EQUALS_TOLERANCE_PER_MIL, done);
         });
@@ -154,7 +154,7 @@ describe('multilayer', function() {
     it("layergroup with 3 mixed layers, mapnik grid.json (layer 0)", function(done) {
         var testClient = new TestClient(layergroupWith3Layers);
         testClient.getTile(0, 0, 0, {layer: 0, format: 'grid.json'}, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.utfgridEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer1.layer0.grid.json', 2, done);
         });
     });
@@ -162,7 +162,7 @@ describe('multilayer', function() {
     it("layergroup with 3 mixed layers, mapnik grid.json (layer 1)", function(done) {
         var testClient = new TestClient(layergroupWith3Layers);
         testClient.getTile(0, 0, 0, {layer: 1, format: 'grid.json'}, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.utfgridEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer1.layer1.grid.json', 2, done);
         });
     });
@@ -170,7 +170,7 @@ describe('multilayer', function() {
     it("layergroup with 3 mixed layers, attributes (layer 1)", function(done) {
         var testClient = new TestClient(layergroupWith3Layers);
         testClient.getFeatureAttributes(1, 4, function (err, attributes) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(attributes, { n: 40 });
             done();
         });
@@ -179,7 +179,7 @@ describe('multilayer', function() {
     it("layergroup with 3 mixed layers, torque.json (layer 2)", function(done) {
         var testClient = new TestClient(layergroupWith3Layers);
         testClient.getTile(0, 0, 0, {layer: 2, format: 'torque.json'}, function (err, torqueTile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(torqueTile[0].vals__uint8, [1]);
             assert.deepEqual(torqueTile[0].dates__uint16, [0]);
             assert.equal(torqueTile[0].x__uint8, 128);
@@ -230,7 +230,7 @@ describe('multilayer', function() {
             function getTile1() {
                 var next = this;
                 testClient1.getTile(0, 0, 0, function(err, tile) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     assert.imageEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer2.png',
                         IMAGE_EQUALS_TOLERANCE_PER_MIL, next);
                 });
@@ -240,7 +240,7 @@ describe('multilayer', function() {
 
                 var next = this;
                 testClient1.getTile(0, 0, 0, {layer: 0, format: 'grid.json'}, function (err, tile) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     assert.utfgridEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer1.layer0.grid.json', 2,
                         next);
                 });
@@ -250,7 +250,7 @@ describe('multilayer', function() {
 
                 var next = this;
                 testClient2.getTile(0, 0, 0, function (err, tile) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     assert.imageEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer3.png',
                         IMAGE_EQUALS_TOLERANCE_PER_MIL, next);
                 });
@@ -260,7 +260,7 @@ describe('multilayer', function() {
 
                 var next = this;
                 testClient2.getTile(0, 0, 0, {layer: 0, format: 'grid.json'}, function (err, tile) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     assert.utfgridEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer1.layer1.grid.json', 2,
                         next);
                 });
@@ -295,7 +295,7 @@ describe('multilayer', function() {
     it("layers are rendered in definition order (create)", function(done) {
         var testClient = new TestClient(layergroupOrder);
         testClient.createLayergroup(function (err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             assert.equal(layergroup.metadata.layers.length, 3);
@@ -306,7 +306,7 @@ describe('multilayer', function() {
     it("layers are rendered in definition order (png)", function(done) {
         var testClient = new TestClient(layergroupOrder);
         testClient.getTile(0, 0, 0, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.imageEqualsFile(tile, './test/fixtures/test_table_0_0_0_multilayer4.png',
                 IMAGE_EQUALS_TOLERANCE_PER_MIL, done);
         });
@@ -330,7 +330,7 @@ describe('multilayer', function() {
         ]
       };
         new TestClient(layergroup).createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             assert.equal(layergroup.metadata.layers.length, 2);
@@ -352,7 +352,7 @@ describe('multilayer', function() {
         ]
       };
         new TestClient(layergroup).createLayergroup(function(err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             assert.equal(layergroup.metadata.layers.length, 1);
@@ -384,7 +384,7 @@ describe('multilayer', function() {
     it('text-wrap-character', function(done) {
         var textName = 'This is a long text that should break into several lines';
         new TestClient(fontLayergroup('DejaVu Sans Book', textName)).getTile(0, 0, 0, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(tile);
             assert.imageEqualsFile(
                 tile,
@@ -406,7 +406,7 @@ describe('multilayer', function() {
 
     it("known text-face-name", function(done) {
         new TestClient(fontLayergroup(available_system_fonts[0])).getTile(0, 0, 0, function (err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(tile);
             done();
         });
@@ -432,7 +432,7 @@ describe('multilayer', function() {
 
         var testClient = new TestClient(layergroup);
         testClient.getTile(0, 0, 0, {layer: 0, format: 'grid.json'}, function (err, grid) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(grid);
 
             assert.ok(grid.hasOwnProperty('data'));
@@ -510,7 +510,7 @@ describe('multilayer', function() {
     it("layergroupid didn't change", function(done) {
         var testClient = new TestClient(layergroupOrder);
         testClient.createLayergroup(function (err, layergroup) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(layergroup);
             assert.ok(layergroup.layergroupid);
             assert.equal(layergroup.layergroupid, '80dc4ccd7d334435d64feaec7f55c4c5');

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -1192,7 +1192,8 @@ function describe_compare_renderer() {
 "POLYGON((-20037508 20037508, 20037508 20037508, 20037508 -20037508, -20037508 -20037508, -20037508 20037508)," +
 "(-18037508 18037508, -18037508 -18037508, 18037508 -18037508, 18037508 18037508, -18037508 18037508))" +
 "'::geometry as the_geom",
-            vector_extent : 256
+            vector_extent : 256,
+            vector_simplify_extent : 256
         },
         {
             name: 'Polygon - Extent 1024',
@@ -1201,7 +1202,8 @@ function describe_compare_renderer() {
 "POLYGON((-20037508 20037508, 20037508 20037508, 20037508 -20037508, -20037508 -20037508, -20037508 20037508)," +
 "(-18037508 18037508, -18037508 -18037508, 18037508 -18037508, 18037508 18037508, -18037508 18037508))" +
 "'::geometry as the_geom",
-            vector_extent : 1024
+            vector_extent : 1024,
+            vector_simplify_extent : 1024
         },
         {
             name: 'One tile optimization',
@@ -1239,7 +1241,8 @@ function describe_compare_renderer() {
 "-189821.934801087 4985133.08649598," +"-189818.054529627 4985129.07872948," +"-189816.829604027 4985127.43227191))" +
 "'::geometry as the_geom, 61374 as cartodb_id",
             tile : { z : 0, x: 0, y: 0 },
-            vector_extent : Math.pow(2, 30)
+            vector_extent : Math.pow(2, 30),
+            vector_simplify_extent : Math.pow(2, 30)
         }
     ];
 
@@ -1254,7 +1257,8 @@ function describe_compare_renderer() {
                             geom_column: 'the_geom',
                             srid: 3857,
                             sql: test.sql,
-                            vector_extent : test.vector_extent || 4096
+                            vector_extent : test.vector_extent || 4096,
+                            vector_simplify_extent : test.vector_simplify_extent || 4096
                         }
                     }
                 ]
@@ -1267,7 +1271,6 @@ function describe_compare_renderer() {
                 mapnik: { grainstore : { datasource : {
                     "row_limit":0,
                     "persist_connection": false,
-                    "simplify_geometries": true,
                     "use_overviews": true,
                     "max_size": 500,
                     "twkb_encoding": true

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -33,7 +33,7 @@ function mvtTest(usePostGIS) {
 
         const testClient = new TestClient(mapConfig, options);
         testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-            assert.ok(!err, err);
+            assert.ifError(err);
 
             const vtile = new mapnik.VectorTile(0, 0, 0);
             vtile.setData(mvtTile);
@@ -162,7 +162,7 @@ function mvtTest(usePostGIS) {
 
     function multipleLayersValidation(done) {
         return function (err, mvtTile) {
-            assert.ok(!err, err);
+            assert.ifError(err);
 
             const vtile = new mapnik.VectorTile(13, 4011, 3088);
             vtile.setData(mvtTile);
@@ -227,7 +227,7 @@ function mvtTest(usePostGIS) {
         it('select one layer', function(done) {
             const testClient = new TestClient(mixedLayersMapConfig, options);
             testClient.getTile(13, 4011, 3088, { layer: 1, format: 'mvt'}, function (err, mvtTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
 
                 const vtile = new mapnik.VectorTile(13, 4011, 3088);
                 vtile.setData(mvtTile);
@@ -298,7 +298,7 @@ function mvtTest(usePostGIS) {
             };
             const testClient = new TestClient(mapConfig, options);
             testClient.getTile(13, 4011, 3088, { layer: '1,3', format: 'mvt'}, function (err, mvtTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
 
                 const vtile = new mapnik.VectorTile(13, 4011, 3088);
                 vtile.setData(mvtTile);
@@ -380,7 +380,7 @@ function mvtTest(usePostGIS) {
             };
             const testClient = new TestClient(mapConfig, options);
             testClient.getTile(13, 4011, 3088, { layer: 'mapnik', format: 'mvt'}, function (err, mvtTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
 
                 const vtile = new mapnik.VectorTile(13, 4011, 3088);
                 vtile.setData(mvtTile);
@@ -459,7 +459,7 @@ function mvtTest(usePostGIS) {
                 mapConfig.layers[0].options.sql = tuple.sql;
                 const testClient = new TestClient(mapConfig, options);
                 testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
 
                     const vtile = new mapnik.VectorTile(0, 0, 0);
                     vtile.setData(mvtTile);
@@ -490,7 +490,7 @@ function mvtTest(usePostGIS) {
                 mapConfig.layers[0].options.vector_simplify_extent = size;
                 const testClient = new TestClient(mapConfig, options);
                 testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
 
                     const vtile = new mapnik.VectorTile(0, 0, 0);
                     vtile.setData(mvtTile);
@@ -779,7 +779,7 @@ function mvtTest(usePostGIS) {
 
             const testClient = new TestClient(mapConfig, options);
             testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
 
                 const vtile = new mapnik.VectorTile(0, 0, 0);
                 vtile.setData(mvtTile);
@@ -820,7 +820,7 @@ function mvtTest(usePostGIS) {
 
             const testClient = new TestClient(mapConfig, options);
             testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 done();
             });
         });
@@ -855,7 +855,7 @@ function mvtTest(usePostGIS) {
 
             const testClient = new TestClient(mapConfig, options);
             testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 done();
             });
         });
@@ -902,10 +902,10 @@ function mvtTest(usePostGIS) {
 
             const testClient = new TestClient(mapConfigOriginal, options);
             testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtOriginal) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 const testClientSimplified = new TestClient(mapConfigPresimplified, options);
                 testClientSimplified.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtSimple) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
                     mvt_cmp(mvtOriginal, mvtSimple);
 
                     // For Mapnik compare again using TWKB this time
@@ -923,10 +923,10 @@ function mvtTest(usePostGIS) {
 
                         const testClientTWKB = new TestClient(mapConfigOriginal, optionsTWKB);
                         testClientTWKB.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtOriginalTWKB) {
-                            assert.ok(!err, err);
+                            assert.ifError(err);
                             const testClientSimpleTWKB = new TestClient(mapConfigPresimplified, optionsTWKB);
                             testClientSimpleTWKB.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtSimpleTWKB) {
-                                assert.ok(!err, err);
+                                assert.ifError(err);
                                 mvt_cmp(mvtOriginalTWKB, mvtSimpleTWKB);
                                 done();
                             });

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -1539,6 +1539,14 @@ function describe_compare_renderer() {
             tile : { z : 0, x: 0, y: 0 },
             vector_extent : Math.pow(2, 30),
             vector_simplify_extent : Math.pow(2, 30)
+        },
+        {
+            name: "!bbox! includes geometries in the buffer zone",
+            tile : { z: 12, x : 1204, y: 1540 },
+            sql :
+"SELECT cartodb_id, St_Transform(tg, 3857) as the_geom FROM ( " +
+"SELECT 2 AS cartodb_id, 'SRID=3857;POINT(-8247459.53332372 4959086.55819354)'::geometry as tg " +
+") _a WHERE tg && !bbox!"
         }
     ];
 

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -72,6 +72,148 @@ function mvtTest(usePostGIS) {
         });
     });
 
+    it('Works with vector_layer_extent in the mapConfig', function (done) {
+        const mapConfig = {
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 1 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                        vector_layer_extent: 666
+                    }
+                }
+            ]
+        };
+
+        this.testClient = new TestClient(mapConfig, options);
+        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+            assert.ok(!err, err);
+
+            const vtile = new mapnik.VectorTile(0, 0, 0);
+            vtile.setData(mvtTile);
+            const result = vtile.toJSON();
+            assert.equal(result[0].extent, 666);
+            assert.equal(result[0].features.length, 1);
+            assert.equal(result[0].features[0].properties.cartodb_id, 1);
+
+            done();
+        });
+    });
+
+    it('Error with multiple vector_layer_extent in the mapConfig', function (done) {
+        const mapConfig = {
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 1 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                        vector_layer_extent: 666
+                    }
+                },
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 4 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                        vector_layer_extent: 777
+                    }
+                }
+            ]
+        };
+
+        this.testClient = new TestClient(mapConfig, options);
+        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
+            assert.ok(err);
+
+            done();
+        });
+    });
+
+    it('Error with multiple vector_layer_extent in the mapConfig (666 and default [4096])', function (done) {
+        const mapConfig = {
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 1 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                        vector_layer_extent: 888
+                    }
+                },
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 4 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
+                    }
+                }
+            ]
+        };
+
+        this.testClient = new TestClient(mapConfig, options);
+        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
+            assert.ok(err);
+
+            done();
+        });
+    });
+
+    it('Should work with multiple vector_layer_extent in the mapConfig (4096 and default [4096])', function (done) {
+        const mapConfig = {
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 1 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                        vector_layer_extent: 4096
+                    }
+                },
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: 'the_geom',
+                        srid: 3857,
+                        sql: 'SELECT 4 AS "cartodb_id", ' +
+                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
+                    }
+                }
+            ]
+        };
+
+        this.testClient = new TestClient(mapConfig, options);
+        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+            assert.ok(!err, err);
+
+            const vtile = new mapnik.VectorTile(0, 0, 0);
+            vtile.setData(mvtTile);
+            const result = vtile.toJSON();
+            assert.equal(result[0].extent, 4096);
+            assert.equal(result[0].features.length, 1);
+            assert.equal(result[0].features[0].properties.cartodb_id, 1);
+
+            done();
+        });
+    });
+
     it('single layer', function (done) {
         const mapConfig = TestClient.mvtLayerMapConfig('select * from test_table', null, null, 'name');
         const testClient = new TestClient(mapConfig, options);

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -1139,8 +1139,8 @@ function describe_compare_renderer() {
 
             testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
                 testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
-                    assert.ok(!err1, err1);
-                    assert.ok(!err2, err2);
+                    assert.ifError(err1);
+                    assert.ifError(err2);
                     assert.deepEqual(mheaders, pheaders);
                     if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);
@@ -1616,8 +1616,8 @@ function describe_compare_renderer() {
 
             testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
                 testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
-                    assert.ok(!err1, err1);
-                    assert.ok(!err2, err2);
+                    assert.ifError(err1);
+                    assert.ifError(err2);
                     assert.deepEqual(mheaders, pheaders);
                     if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -500,9 +500,9 @@ function mvtExtractComponents(geometry) {
     });
 }
 
-// Compares (with a tolerance of +- 2) an array of points
+// Compares (with a tolerance of +- 1) an array of points
 function mvtPointArray_cmp(arr1, arr2) {
-    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 2));
+    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 1));
     assert.equal(arr1.length, 0, "Items not found in Mapnik's: " + JSON.stringify(arr1));
 }
 

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -54,9 +54,8 @@ function mvtTest(usePostGIS) {
             const mapConfig = TestClient.mvtLayerMapConfig(sql, null, null, 'name');
             mapConfig.layers[0].options.geom_column = 'the_geom';
             mapConfig.layers[0].options.srid = 3857;
-            const extent_options = JSON.parse(JSON.stringify(options));
-            extent_options.mvt.vector_layer_extent = size;
-            this.testClient = new TestClient(mapConfig, extent_options);
+            mapConfig.layers[0].options.vector_layer_extent = size;
+            this.testClient = new TestClient(mapConfig, options);
             this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
                 assert.ok(!err, err);
 
@@ -1256,7 +1255,8 @@ function describe_compare_renderer() {
                         options: {
                             geom_column: 'the_geom',
                             srid: 3857,
-                            sql: test.sql
+                            sql: test.sql,
+                            vector_layer_extent : test.vector_layer_extent || 4096
                         }
                     }
                 ]
@@ -1264,8 +1264,7 @@ function describe_compare_renderer() {
 
             const mapnikOptions = {
                 mvt: {
-                    usePostGIS: false,
-                    vector_layer_extent : test.vector_layer_extent || 4096
+                    usePostGIS: false
                 },
                 mapnik: { grainstore : { datasource : {
                     "row_limit":0,
@@ -1279,8 +1278,7 @@ function describe_compare_renderer() {
 
             const pgOptions = {
                 mvt : {
-                    usePostGIS: true,
-                    vector_layer_extent : test.vector_layer_extent || 4096
+                    usePostGIS: true
                 }
             };
 

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -80,6 +80,17 @@ function mvtTest(usePostGIS) {
         });
     });
 
+    it('Layer without sql', function (done) {
+        const mapConfig = TestClient.singleLayerMapConfig('select * from test_table', null, null, 'name');
+        delete mapConfig.layers[0].options.sql;
+        const testClient = new TestClient(mapConfig, options);
+
+        testClient.getTile(13, 4011, 3088, { layer: 'mapnik', format: 'mvt' }, function (err) {
+            assert.ok(err);
+            done();
+        });
+    });
+
     const multipleLayersMapConfig =  {
         version: '1.3.0',
         layers: [

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -500,9 +500,9 @@ function mvtExtractComponents(geometry) {
     });
 }
 
-// Compares (with a tolerance of +- 1) an array of points
+// Compares (with a tolerance of +- 2) an array of points
 function mvtPointArray_cmp(arr1, arr2) {
-    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 1));
+    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 2));
     assert.equal(arr1.length, 0, "Items not found in Mapnik's: " + JSON.stringify(arr1));
 }
 
@@ -652,18 +652,32 @@ function describe_compare_renderer() {
     LAYER_TESTS.forEach(test => {
         it(test.name, function (done) {
 
-            const testClientMapnik = new TestClient(test.mapConfig, { mvt: { usePostGIS: false } });
-            const testClientPg_mvt = new TestClient(test.mapConfig, { mvt: { usePostGIS: true } });
-            const options = { format : 'mvt' };
+            const mapnikOptions = {
+                mvt : {
+                    usePostGIS: true,
+                }
+            };
 
-            testClientMapnik.getTile(test.tile.z, test.tile.x, test.tile.y, options, function (err1, mapnikMVT) {
-                testClientPg_mvt.getTile(test.tile.z, test.tile.x, test.tile.y, options, function (err2, pgMVT) {
-                    if (test.expectedError) {
-                        assert.equal(err1, test.expectedError);
-                        assert.equal(err2, test.expectedError);
-                    } else {
-                        assert.ok(!err1, err1);
-                        assert.ok(!err2, err2);
+            const pgOptions = {
+                mvt : {
+                    usePostGIS: false
+                }
+            };
+
+            const testClientMapnik = new TestClient(test.mapConfig, mapnikOptions);
+            const testClientPg_mvt = new TestClient(test.mapConfig, pgOptions);
+
+            const tileOptions = { format : 'mvt' };
+            const z = test.tile && test.tile.z ? test.tile.z : 0;
+            const x = test.tile && test.tile.x ? test.tile.x : 0;
+            const y = test.tile && test.tile.y ? test.tile.y : 0;
+
+            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
+                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
+                    assert.ok(!err1, err1);
+                    assert.ok(!err2, err2);
+                    assert.deepEqual(mheaders, pheaders);
+                    if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);
                     }
 
@@ -673,14 +687,11 @@ function describe_compare_renderer() {
         });
     });
 
-    const emptyTileError = "Error: Tile does not exist";
 
     const GEOM_TESTS = [
-
         {
             name: 'Null geometry',
-            sql: "SELECT 2 AS cartodb_id, null as the_geom",
-            expectedError : emptyTileError
+            sql: "SELECT 2 AS cartodb_id, null as the_geom"
         },
         {
             name: 'Empty tile',
@@ -688,8 +699,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POINT(-293823 5022065)" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Point',
@@ -731,8 +741,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "LINESTRING(-293823 5022065, -293823 5022065)" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Linestring (repeated points)',
@@ -746,7 +755,8 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "LINESTRING(0 20037508, 0 0, 0 10037508, 0 -10037508, 0 -20037508)" +
-"'::geometry as the_geom"
+"'::geometry as the_geom",
+            tile : { z : 12, x: 12, y: 12 },
         },
         {
             name: 'Linestring (join segments)',
@@ -850,8 +860,7 @@ function describe_compare_renderer() {
             sql:
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POLYGON((-20037508 20037508, 20037508 -20037508, 20037508 -20037508, 20037508 -20037508, -20037508 20037508))" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Polygon (Duplicates but still valid)',
@@ -901,8 +910,7 @@ function describe_compare_renderer() {
 "SELECT 2 AS cartodb_id, 'SRID=3857;" +
 "POLYGON((-20037508 20037508, -20037508 20037508, -20037508 20037508, -20037508 20037508, " +
 "-20037508 20037508, -20037508 20037508))" +
-"'::geometry as the_geom",
-            expectedError : emptyTileError
+"'::geometry as the_geom"
         },
         {
             name: 'Polygon (Self intersection)',
@@ -1006,8 +1014,7 @@ function describe_compare_renderer() {
 "-189856.496116557 4985163.78358654,-189845.714632381 4985154.8544578,-189836.125895049 4985146.44147802," +
 "-189821.934801087 4985133.08649598," +"-189818.054529627 4985129.07872948," +"-189816.829604027 4985127.43227191))" +
 "'::geometry as the_geom, 61374 as cartodb_id",
-            knownIssue : "Mapnik uses a tile size of 256 to simplify (instead of 4096) and a different formula " +
-                         "Should be more similar after https://github.com/CartoDB/Windshaft/issues/641 is done"
+            knownIssue : "Mapnik uses a different formula for simplification to adapt to TWKB grid"
         }
     ];
 
@@ -1041,21 +1048,25 @@ function describe_compare_renderer() {
                 }}}
             };
 
+            const pgOptions = {
+                mvt : {
+                    usePostGIS: true
+                }
+            };
+
             const testClientMapnik = new TestClient(mapConfig, mapnikOptions);
-            const testClientPg_mvt = new TestClient(mapConfig, { mvt: { usePostGIS: true } });
+            const testClientPg_mvt = new TestClient(mapConfig, pgOptions);
             const tileOptions = { format : 'mvt' };
             const z = test.tile && test.tile.z ? test.tile.z : 0;
             const x = test.tile && test.tile.x ? test.tile.x : 0;
             const y = test.tile && test.tile.y ? test.tile.y : 0;
 
-            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT) {
-                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT) {
-                    if (test.expectedError) {
-                        assert.equal(err1, test.expectedError);
-                        assert.equal(err2, test.expectedError);
-                    } else {
-                        assert.ok(!err1, err1);
-                        assert.ok(!err2, err2);
+            testClientMapnik.getTile(z, x, y, tileOptions, function (err1, mapnikMVT, img, mheaders) {
+                testClientPg_mvt.getTile(z, x, y, tileOptions, function (err2, pgMVT, img, pheaders) {
+                    assert.ok(!err1, err1);
+                    assert.ok(!err2, err2);
+                    assert.deepEqual(mheaders, pheaders);
+                    if (mheaders['x-tilelive-contains-data']) {
                         mvt_cmp(mapnikMVT, pgMVT);
                     }
 

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -31,8 +31,8 @@ function mvtTest(usePostGIS) {
         mapConfig.layers[0].options.geom_column = 'the_geom';
         mapConfig.layers[0].options.srid = 3857;
 
-        this.testClient = new TestClient(mapConfig, options);
-        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+        const testClient = new TestClient(mapConfig, options);
+        testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
             assert.ok(!err, err);
 
             const vtile = new mapnik.VectorTile(0, 0, 0);
@@ -41,173 +41,6 @@ function mvtTest(usePostGIS) {
 
             assert.equal(result[0].features.length, 1);
             assert.strictEqual(result[0].features[0].properties["cartodb id"], 1);
-
-            done();
-        });
-    });
-
-    [256, 666, 1024, 2222, 4096, 10000, 4096 * Math.pow(2,18)]
-    .forEach(size => {
-        it('Works with vector_layer_extent '+ size, function (done) {
-            const sql = 'SELECT ' + size + ' AS "cartodb_id", ' +
-                                "'SRID=3857;LINESTRING(-293823 5022065, 3374847 8386059)'::geometry as the_geom";
-            const mapConfig = TestClient.mvtLayerMapConfig(sql, null, null, 'name');
-            mapConfig.layers[0].options.geom_column = 'the_geom';
-            mapConfig.layers[0].options.srid = 3857;
-            mapConfig.layers[0].options.vector_layer_extent = size;
-            this.testClient = new TestClient(mapConfig, options);
-            this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-                assert.ok(!err, err);
-
-                const vtile = new mapnik.VectorTile(0, 0, 0);
-                vtile.setData(mvtTile);
-                const result = vtile.toJSON();
-                assert.equal(result[0].extent, size);
-                assert.equal(result[0].features.length, 1);
-                assert.equal(result[0].features[0].properties.cartodb_id, size);
-
-                done();
-            });
-        });
-    });
-
-    it('Works with vector_layer_extent in the mapConfig', function (done) {
-        const mapConfig = {
-            version: '1.8.0',
-            layers: [
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 1 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
-                        vector_layer_extent: 666
-                    }
-                }
-            ]
-        };
-
-        this.testClient = new TestClient(mapConfig, options);
-        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-            assert.ok(!err, err);
-
-            const vtile = new mapnik.VectorTile(0, 0, 0);
-            vtile.setData(mvtTile);
-            const result = vtile.toJSON();
-            assert.equal(result[0].extent, 666);
-            assert.equal(result[0].features.length, 1);
-            assert.equal(result[0].features[0].properties.cartodb_id, 1);
-
-            done();
-        });
-    });
-
-    it('Error with multiple vector_layer_extent in the mapConfig', function (done) {
-        const mapConfig = {
-            version: '1.8.0',
-            layers: [
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 1 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
-                        vector_layer_extent: 666
-                    }
-                },
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 4 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
-                        vector_layer_extent: 777
-                    }
-                }
-            ]
-        };
-
-        this.testClient = new TestClient(mapConfig, options);
-        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
-            assert.ok(err);
-
-            done();
-        });
-    });
-
-    it('Error with multiple vector_layer_extent in the mapConfig (666 and default [4096])', function (done) {
-        const mapConfig = {
-            version: '1.8.0',
-            layers: [
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 1 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
-                        vector_layer_extent: 888
-                    }
-                },
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 4 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
-                    }
-                }
-            ]
-        };
-
-        this.testClient = new TestClient(mapConfig, options);
-        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
-            assert.ok(err);
-
-            done();
-        });
-    });
-
-    it('Should work with multiple vector_layer_extent in the mapConfig (4096 and default [4096])', function (done) {
-        const mapConfig = {
-            version: '1.8.0',
-            layers: [
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 1 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
-                        vector_layer_extent: 4096
-                    }
-                },
-                {
-                    type: 'mapnik',
-                    options: {
-                        geom_column: 'the_geom',
-                        srid: 3857,
-                        sql: 'SELECT 4 AS "cartodb_id", ' +
-                             "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
-                    }
-                }
-            ]
-        };
-
-        this.testClient = new TestClient(mapConfig, options);
-        this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
-            assert.ok(!err, err);
-
-            const vtile = new mapnik.VectorTile(0, 0, 0);
-            vtile.setData(mvtTile);
-            const result = vtile.toJSON();
-            assert.equal(result[0].extent, 4096);
-            assert.equal(result[0].features.length, 1);
-            assert.equal(result[0].features[0].properties.cartodb_id, 1);
 
             done();
         });
@@ -624,8 +457,8 @@ function mvtTest(usePostGIS) {
         SQL.forEach(function(tuple){
             it('bool and int iteration ' + tuple.name, function (done) {
                 mapConfig.layers[0].options.sql = tuple.sql;
-                this.testClient = new TestClient(mapConfig, options);
-                this.testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+                const testClient = new TestClient(mapConfig, options);
+                testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
                     assert.ok(!err, err);
 
                     const vtile = new mapnik.VectorTile(0, 0, 0);
@@ -639,6 +472,171 @@ function mvtTest(usePostGIS) {
 
                     done();
                 });
+            });
+        });
+    });
+
+    describe('`vector_extent`', function() {
+
+        [256, 666, 1024, 2222, 4096, 10000, 4096 * Math.pow(2,18)]
+        .forEach(size => {
+            it('Works with '+ size, function (done) {
+                const sql = 'SELECT ' + size + ' AS "cartodb_id", ' +
+                                    "'SRID=3857;LINESTRING(-293823 5022065, 3374847 8386059)'::geometry as the_geom";
+                const mapConfig = TestClient.mvtLayerMapConfig(sql, null, null, 'name');
+                mapConfig.layers[0].options.geom_column = 'the_geom';
+                mapConfig.layers[0].options.srid = 3857;
+                mapConfig.layers[0].options.vector_extent = size;
+                const testClient = new TestClient(mapConfig, options);
+                testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+                    assert.ok(!err, err);
+
+                    const vtile = new mapnik.VectorTile(0, 0, 0);
+                    vtile.setData(mvtTile);
+                    const result = vtile.toJSON();
+                    assert.equal(result[0].extent, size);
+                    assert.equal(result[0].features.length, 1);
+                    assert.equal(result[0].features[0].properties.cartodb_id, size);
+
+                    done();
+                });
+            });
+        });
+
+        [0, Math.pow(2,31), 'Huracán']
+        .forEach(size => {
+            it('Fails with ' + size, function (done) {
+                const mapConfig = {
+                    version: '1.8.0',
+                    layers: [
+                        {
+                            type: 'mapnik',
+                            options: {
+                                geom_column: 'the_geom',
+                                srid: 3857,
+                                sql: 'SELECT 1 AS "cartodb_id", ' +
+                                     "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                                vector_extent: size
+                            }
+                        }
+                    ]
+                };
+
+                const testClient = new TestClient(mapConfig, options);
+                testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
+                    assert.notEqual(err, undefined);
+                    done();
+                });
+            });
+        });
+
+        it('Fails with multiple vector_extent in the mapConfig', function (done) {
+            const mapConfig = {
+                version: '1.8.0',
+                layers: [
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 1 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                            vector_extent: 666
+                        }
+                    },
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 4 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                            vector_extent: 777
+                        }
+                    }
+                ]
+            };
+
+            const testClient = new TestClient(mapConfig, options);
+            testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
+                assert.notEqual(err, undefined);
+
+                done();
+            });
+        });
+
+        it('Fails with multiple vector_extent in the mapConfig (666 and default [4096])', function (done) {
+            const mapConfig = {
+                version: '1.8.0',
+                layers: [
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 1 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                            vector_extent: 888
+                        }
+                    },
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 4 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
+                        }
+                    }
+                ]
+            };
+
+            const testClient = new TestClient(mapConfig, options);
+            testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err) {
+                assert.notEqual(err, undefined);
+
+                done();
+            });
+        });
+
+        it('Works with multiple vector_extent in the mapConfig (4096 and default [4096])', function (done) {
+            const mapConfig = {
+                version: '1.8.0',
+                layers: [
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 1 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom",
+                            vector_extent: 4096
+                        }
+                    },
+                    {
+                        type: 'mapnik',
+                        options: {
+                            geom_column: 'the_geom',
+                            srid: 3857,
+                            sql: 'SELECT 4 AS "cartodb_id", ' +
+                                 "'SRID=3857;POINT(-293823 5022065)'::geometry as the_geom"
+                        }
+                    }
+                ]
+            };
+
+            const testClient = new TestClient(mapConfig, options);
+            testClient.getTile(0, 0, 0, { format: 'mvt' }, function (err, mvtTile) {
+                assert.ok(!err, err);
+
+                const vtile = new mapnik.VectorTile(0, 0, 0);
+                vtile.setData(mvtTile);
+                const result = vtile.toJSON();
+                assert.equal(result[0].extent, 4096);
+                assert.equal(result[0].features.length, 1);
+                assert.equal(result[0].features[0].properties.cartodb_id, 1);
+
+                done();
             });
         });
     });
@@ -677,9 +675,9 @@ function mvtExtractComponents(geometry) {
     });
 }
 
-// Compares (with a tolerance of +- 1) an array of points
+// Compares (with a tolerance of +- 2) an array of points
 function mvtPointArray_cmp(arr1, arr2) {
-    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 1 && Math.abs(p1.y - p2.y) <= 1));
+    arr1 = arr1.filter(p1 => !arr2.find(p2 => Math.abs(p1.x - p2.x) <= 2 && Math.abs(p1.y - p2.y) <= 2));
     assert.equal(arr1.length, 0, "Items not found in Mapnik's: " + JSON.stringify(arr1));
 }
 
@@ -1194,7 +1192,7 @@ function describe_compare_renderer() {
 "POLYGON((-20037508 20037508, 20037508 20037508, 20037508 -20037508, -20037508 -20037508, -20037508 20037508)," +
 "(-18037508 18037508, -18037508 -18037508, 18037508 -18037508, 18037508 18037508, -18037508 18037508))" +
 "'::geometry as the_geom",
-            vector_layer_extent : 256
+            vector_extent : 256
         },
         {
             name: 'Polygon - Extent 1024',
@@ -1203,7 +1201,7 @@ function describe_compare_renderer() {
 "POLYGON((-20037508 20037508, 20037508 20037508, 20037508 -20037508, -20037508 -20037508, -20037508 20037508)," +
 "(-18037508 18037508, -18037508 -18037508, 18037508 -18037508, 18037508 18037508, -18037508 18037508))" +
 "'::geometry as the_geom",
-            vector_layer_extent : 1024
+            vector_extent : 1024
         },
         {
             name: 'One tile optimization',
@@ -1241,7 +1239,7 @@ function describe_compare_renderer() {
 "-189821.934801087 4985133.08649598," +"-189818.054529627 4985129.07872948," +"-189816.829604027 4985127.43227191))" +
 "'::geometry as the_geom, 61374 as cartodb_id",
             tile : { z : 0, x: 0, y: 0 },
-            vector_layer_extent : 4096 * Math.pow(2, 18)
+            vector_extent : Math.pow(2, 30)
         }
     ];
 
@@ -1256,7 +1254,7 @@ function describe_compare_renderer() {
                             geom_column: 'the_geom',
                             srid: 3857,
                             sql: test.sql,
-                            vector_layer_extent : test.vector_layer_extent || 4096
+                            vector_extent : test.vector_extent || 4096
                         }
                     }
                 ]

--- a/test/acceptance/raster.js
+++ b/test/acceptance/raster.js
@@ -29,7 +29,7 @@ describe('raster', function() {
 
         var testClient = new TestClient(mapconfig);
         testClient.getTile(0, 0, 0, function(err, tile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.imageEqualsFile(tile, './test/fixtures/raster_gray_rect.png', IMAGE_EQUALS_TOLERANCE_PER_MIL, done);
         });
 
@@ -89,7 +89,7 @@ describe('raster', function() {
 
         var testClient = new TestClient(mapconfig);
         testClient.getTile(0, 0, 0, function(err, tile, img) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(tile);
             assert.equal(img.width(), 256);
             done();

--- a/test/acceptance/static_maps.js
+++ b/test/acceptance/static_maps.js
@@ -72,7 +72,7 @@ describe('static_maps', function() {
     it('center image', function (done) {
         var testClient = new TestClient(staticMapConfig(validUrlTemplate));
         testClient.getStaticCenter(zoom, lon, lat, width, height, function(err, imageBuffer, image) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.equal(image.width(), width);
             assert.equal(image.height(), height);
 
@@ -83,7 +83,7 @@ describe('static_maps', function() {
     it('center image with invalid basemap', function (done) {
         var testClient = new TestClient(staticMapConfig(invalidUrlTemplate));
         testClient.getStaticCenter(zoom, lon, lat, width, height, function(err, imageBuffer, image) {
-            assert.ok(!err);
+            assert.ifError(err);
 
             assert.equal(image.width(), width);
             assert.equal(image.height(), height);
@@ -102,7 +102,7 @@ describe('static_maps', function() {
     it('bbox', function (done) {
         var testClient = new TestClient(staticMapConfig(validUrlTemplate));
         testClient.getStaticBbox(west, south, east, north, bbWidth, bbHeight, function(err, imageBuffer, image) {
-            assert.ok(!err);
+            assert.ifError(err);
 
             assert.equal(image.width(), bbWidth);
             assert.equal(image.height(), bbHeight);
@@ -115,7 +115,7 @@ describe('static_maps', function() {
         var outOfRangeHeight = 3000;
         var testClient = new TestClient(staticMapConfig(validUrlTemplate));
         testClient.getStaticCenter(1, lat, lon, width, outOfRangeHeight, function(err, imageBuffer, image) {
-            assert.ok(!err);
+            assert.ifError(err);
 
             assert.equal(image.width(), width);
             assert.equal(image.height(), outOfRangeHeight);

--- a/test/acceptance/torque-steps.js
+++ b/test/acceptance/torque-steps.js
@@ -125,9 +125,9 @@ describe('torque steps', function () {
         it(`should sort dates and vals — step=${step}`, function (done) {
             var testClient = new TestClient(torqueMapConfig(step));
             testClient.getTile(0, 0, 0, { layer: 0, format: 'png' }, function (err, torqueTile) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 assert.imageEqualsFile(torqueTile, torquePngFixture(step), IMAGE_TOLERANCE_PER_MIL, function(err) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     done();
                 });
             });
@@ -137,7 +137,7 @@ describe('torque steps', function () {
     it('should sort dates and vals torque.json', function (done) {
         var testClient = new TestClient(torqueMapConfig(undefined));
         testClient.getTile(0, 0, 0, { layer: 0, format: 'torque.json' }, function (err, torqueTile) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.ok(torqueTile);
             assert.deepEqual(torqueTile, expectedTorqueTile);
             done();
@@ -155,9 +155,9 @@ describe('torque steps', function () {
             it(`should be order independent -order=${order_by_step} - step=${step}`, function (done) {
                 var testClient = new TestClient(torqueMapConfig(step));
                 testClient.getTile(0, 0, 0, { layer: 0, format: 'png' }, function (err, torqueTile) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
                     assert.imageEqualsFile(torqueTile, torquePngFixture(step), IMAGE_TOLERANCE_PER_MIL, function(err) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         done();
                     });
                 });

--- a/test/acceptance/torque.js
+++ b/test/acceptance/torque.js
@@ -135,7 +135,7 @@ describe('torque', function() {
 
             var testClient = new TestClient(validTorqueMapConfig);
             testClient.getTile(0, 0, 0, {layer: 0, format: format}, function(err, torqueTile) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.deepEqual(torqueTile, expectedTorqueTileAt_0_0_0);
                 done();
             });
@@ -294,7 +294,7 @@ describe('torque', function() {
         testClient.getTile(0, 0, 0, {layer: 0, format: 'torque.json'}, function(err, torqueTile) {
             SubstitutionTokens.replace = replaceFn;
 
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.deepEqual(torqueTile, [{ x__uint8: 128, y__uint8: 128, vals__uint8: [2,3], dates__uint16: [1,0] }]);
 
             assert.equal(expectedSubstitutionTokens.length, 0);

--- a/test/acceptance/torque_png.js
+++ b/test/acceptance/torque_png.js
@@ -99,7 +99,7 @@ describe('torque png renderer', function() {
             it('torque png tile ' + zxy.join('/') + '.png', function (done) {
                 testClient.getTile(z, x, y, {layer: 0}, function(err, tile) {
                     assert.imageEqualsFile(tile, torquePngFixture(zxy), IMAGE_TOLERANCE_PER_MIL, function(err) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         done();
                     });
                 });
@@ -144,7 +144,7 @@ describe('torque png renderer', function() {
                 assert.imageEqualsFile(tile, fixtureFileCairoLT_1_14, IMAGE_TOLERANCE_PER_MIL, function(err) {
                     if (err) {
                         assert.imageEqualsFile(tile, fixtureFile, IMAGE_TOLERANCE_PER_MIL, function(err) {
-                            assert.ok(!err, err);
+                            assert.ifError(err);
                             done();
                         });
                     } else {
@@ -204,7 +204,7 @@ describe('torque png renderer', function() {
                 h = 400;
             var testClient = new TestClient(mapConfigTorqueOffset);
             testClient.getStaticBbox(-170, -87, 170, 87, w, h, function(err, imageBuffer, img) {
-                assert.ok(!err);
+                assert.ifError(err);
 
                 assert.equal(img.width(), w);
                 assert.equal(img.height(), h);

--- a/test/acceptance/torque_regressions.js
+++ b/test/acceptance/torque_regressions.js
@@ -28,7 +28,7 @@ describe('torque regression', function() {
 
         var testClient = new TestClient(londonPointMapConfig);
         testClient.getTile(2, 1, 1, {layer: 0, format: 'torque.json'}, function(err, torqueTile) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.deepEqual(torqueTile, [{
                 x__uint8: 255,
                 y__uint8: 172,
@@ -72,7 +72,7 @@ describe('torque regression', function() {
 
         var testClient = new TestClient(resolutionTwoMapConfig);
         testClient.getTile(13, 4255, 2765, {layer: 0, format: 'torque.json'}, function(err, torqueTile) {
-            assert.ok(!err);
+            assert.ifError(err);
             /* Sort torqueTile with x___uint8 ascending */
             torqueTile.sort(function(a,b) {
                 return (a.x__uint8 > b.x__uint8);

--- a/test/acceptance/wrap.js
+++ b/test/acceptance/wrap.js
@@ -92,7 +92,7 @@ describe('wrap x coordinate', function() {
                 var testClient = new TestClient(plainTorqueMapConfig(testScenario.plainColor));
                 testClient.getTile(tileRequest.z, tileRequest.x, tileRequest.y, function(err, tile) {
                     assert.imageEqualsFile(tile, blendPngFixture(fixtureZxy), IMG_TOLERANCE_PER_MIL, function(err) {
-                        assert.ok(!err);
+                        assert.ifError(err);
                         done();
                     });
                 });
@@ -104,7 +104,7 @@ describe('wrap x coordinate', function() {
         it("can get a tile with negative x coordinate",  function(done){
             var testClient = new TestClient(TestClient.defaultTableMapConfig('test_table'));
             testClient.getTile(2, -2, 1, function(err, res, img) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.ok(img);
                 assert.equal(img.width(), 256);
                 assert.equal(img.height(), 256);

--- a/test/acceptance/zoom-min-max.js
+++ b/test/acceptance/zoom-min-max.js
@@ -213,13 +213,10 @@ describe('minzoom and maxzoom', function() {
 
         const layersValidator = (z, x, y, expectedLayers, done) => {
             return (err, mvtTile) => {
+                assert.ok(!err, err);
                 if (expectedLayers.length === 0) {
-                    assert.ok(err);
-                    assert.equal(err.message, 'Tile does not exist');
                     return done();
                 }
-
-                assert.ok(!err, err);
 
                 var vtile = new mapnik.VectorTile(0, 0, 0);
                 vtile.setData(mvtTile);

--- a/test/acceptance/zoom-min-max.js
+++ b/test/acceptance/zoom-min-max.js
@@ -200,7 +200,7 @@ describe('minzoom and maxzoom', function() {
                     fixturePath(`layers--${scenario.expectedLayers.join('-')}--z${scenario.z}`);
                 var testClient = new TestClient(mapconfig);
                 testClient.getTile(scenario.z, scenario.x, scenario.y, function(err, tile, img) {
-                    assert.ok(!err, err);
+                    assert.ifError(err);
                     assert.ok(tile);
                     assert.ok(img);
                     assert.imageEqualsFile(tile, fixture, IMAGE_TOLERANCE_PER_MIL, done);
@@ -213,7 +213,7 @@ describe('minzoom and maxzoom', function() {
 
         const layersValidator = (z, x, y, expectedLayers, done) => {
             return (err, mvtTile) => {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 if (expectedLayers.length === 0) {
                     return done();
                 }

--- a/test/integration/renderers/blend_factory.js
+++ b/test/integration/renderers/blend_factory.js
@@ -45,7 +45,7 @@ describe('renderer_http_factory_getRenderer', function() {
     describe('happy case', function() {
         it('getRenderer creates renderer for valid filtered layers', function(done) {
             blendFactory.getRenderer(mapConfig, 'png', rendererOptions(1, 2), function(err, renderer) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.ok(renderer);
                 done();
             });

--- a/test/integration/renderers/http_factory.js
+++ b/test/integration/renderers/http_factory.js
@@ -77,7 +77,7 @@ describe('renderer_http_factory_getRenderer', function() {
             ]
         });
         factoryWithFallbackImage.getRenderer(mapConfig, 'png', layerZeroOptions, function(err, renderer) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(renderer);
             assert.equal(renderer.constructor, HttpFallbackRenderer);
             done();
@@ -102,7 +102,7 @@ describe('renderer_http_factory_getRenderer', function() {
             ]
         });
         factoryWithFallbackImage.getRenderer(mapConfig, 'png', layerZeroOptions, function(err, renderer) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(renderer);
             assert.equal(renderer.constructor, Renderer);
             done();
@@ -128,7 +128,7 @@ describe('renderer_http_factory_getRenderer', function() {
                 ]
             });
             factoryWithFallbackImage.getRenderer(mapConfig, 'png', layerZeroOptions, function(err, renderer) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.ok(renderer);
                 assert.equal(renderer.constructor, Renderer);
                 assert.equal(renderer.subdomains.length, 3);
@@ -151,7 +151,7 @@ describe('renderer_http_factory_getRenderer', function() {
                 ]
             });
             factoryWithFallbackImage.getRenderer(mapConfig, 'png', layerZeroOptions, function(err, renderer) {
-                assert.ok(!err);
+                assert.ifError(err);
                 assert.ok(renderer);
                 assert.equal(renderer.constructor, Renderer);
                 assert.equal(renderer.subdomains.length, 0);

--- a/test/integration/renderers/plain_factory.js
+++ b/test/integration/renderers/plain_factory.js
@@ -110,7 +110,7 @@ describe('renderer_plain_factory_getRenderer', function() {
                 ]
             });
             factory.getRenderer(mapConfig, 'png', rendererOptions(0), function(err, renderer) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 assert.ok(renderer);
                 done();
             });
@@ -179,7 +179,7 @@ describe('renderer_plain_factory_getRenderer', function() {
             ]
         });
         factory.getRenderer(mapConfig, 'png', rendererOptions(0), function(err, renderer) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.ok(renderer);
             done();
         });
@@ -220,7 +220,7 @@ describe('renderer_plain_factory_getRenderer', function() {
             ]
         });
         factory.getRenderer(mapConfig, 'png', rendererOptions(0), function(err, renderer) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.ok(renderer);
             assert.equal(renderer.constructor, ColorRenderer);
             done();

--- a/test/integration/renderers/plain_image_renderer.js
+++ b/test/integration/renderers/plain_image_renderer.js
@@ -36,7 +36,7 @@ describe('renderer_plain_image_renderer', function() {
             it('should render image background with image ' + pattern + ' for ' + zxy.join('/'), function(done) {
                 var imageRenderer = new ImageRenderer(buffers[pattern]);
                 function validate(err, tile) {
-                    assert.ok(!err);
+                    assert.ifError(err);
                     assert.ok(tile);
                     var image = Image.fromBytes(tile);
                     var fixtureFilename = __dirname +

--- a/test/support/test_client.js
+++ b/test/support/test_client.js
@@ -199,7 +199,7 @@ function singleLayerMapConfig(sql, cartocss, cartocssVersion, interactivity, att
 
 function mvtLayerMapConfig(sql, geom_column = 'the_geom', srid = 3857) {
     return {
-            version: '1.7.0',
+            version: '1.8.0',
             layers: [
                 {
                     type: 'mapnik',

--- a/test/support/test_client.js
+++ b/test/support/test_client.js
@@ -32,7 +32,7 @@ var rendererFactoryOptions = {
 };
 
 function TestClient(mapConfig, overrideOptions, onTileErrorStrategy) {
-    var options = _.extend({}, rendererFactoryOptions);
+    const options = _.extend({}, JSON.parse(JSON.stringify(rendererFactoryOptions)));
     overrideOptions = overrideOptions || {};
     _.each(overrideOptions, function(overrideConfig, key) {
         options[key] = _.extend({}, options[key], overrideConfig);
@@ -197,6 +197,23 @@ function singleLayerMapConfig(sql, cartocss, cartocssVersion, interactivity, att
     };
 }
 
+function mvtLayerMapConfig(sql, geom_column = 'the_geom', srid = 3857) {
+    return {
+            version: '1.7.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        geom_column: geom_column,
+                        srid: srid,
+                        sql: sql
+                    }
+                }
+            ]
+    };
+}
+
+
 function defaultTableQuery(tableName) {
     return _.template('SELECT * FROM <%= tableName %>', {tableName: tableName});
 }
@@ -207,6 +224,7 @@ function defaultTableMapConfig(tableName, cartocss, cartocssVersion, interactivi
 
 module.exports.singleLayerMapConfig = singleLayerMapConfig;
 module.exports.defaultTableMapConfig = defaultTableMapConfig;
+module.exports.mvtLayerMapConfig = mvtLayerMapConfig;
 
 module.exports.grainstoreOptions = grainstoreOptions;
 module.exports.mapnikOptions = rendererOptions.mapnik;

--- a/test/unit/torque.test.js
+++ b/test/unit/torque.test.js
@@ -100,7 +100,7 @@ describe('torque', function() {
         }]
       ];
       torque.getRenderer(mapConfig, 'json.torque', layerZeroOptions, function(err, renderer) {
-        assert.ok(!err, err);
+        assert.ifError(err);
         assert.ok(!!renderer);
         assert.ok(!!renderer.getTile);
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,19 @@
 # yarn lockfile v1
 
 
-"@carto/mapnik@3.6.2-carto.10":
-  version "3.6.2-carto.10"
-  resolved "https://registry.yarnpkg.com/@carto/mapnik/-/mapnik-3.6.2-carto.10.tgz#a97c951dcdac09d0eb35b3ea71e5eeaa206c1af6"
+"@carto/mapnik@3.6.2-carto.11":
+  version "3.6.2-carto.11"
+  resolved "https://registry.yarnpkg.com/@carto/mapnik/-/mapnik-3.6.2-carto.11.tgz#f2f0bc4d0051080169267c5c729b90c6bc934661"
   dependencies:
-    mapnik-vector-tile cartodb/mapnik-vector-tile#v1.6.1-carto.1
+    mapnik-vector-tile cartodb/mapnik-vector-tile#v1.6.1-carto.2
     nan "2.10.0"
     node-pre-gyp "0.10.0"
-    protozero "1.5.1"
 
-"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb9":
-  version "2.5.1-cdb9"
-  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/5129e43223cb55daed31373c7a36c98eb6178fc1"
+"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb10":
+  version "2.5.1-cdb10"
+  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/118ac7e7f6582ac7be0fc0246ea2afd1a7795a43"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
+    "@carto/mapnik" "3.6.2-carto.11"
     "@mapbox/sphericalmercator" "~1.0.1"
     mapnik-pool "~0.1.3"
 
@@ -23,13 +22,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
 
-abaculus@cartodb/abaculus#2.0.3-cdb10:
-  version "2.0.3-cdb10"
-  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/90d537028bb8af8a35e7a40c46493066dd8a76b3"
+abaculus@cartodb/abaculus#2.0.3-cdb11:
+  version "2.0.3-cdb11"
+  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/b2d4dce48c50fefc5b06f21c6365d82ccf75358d"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
+    "@carto/mapnik" "3.6.2-carto.11"
     d3-queue "^2.0.2"
-    sphericalmercator "1.0.x"
+    sphericalmercator "1.0.5"
 
 abbrev@1:
   version "1.1.1"
@@ -739,6 +738,10 @@ generic-pool@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.3.tgz#780c36f69dfad05a5a045dd37be7adca11a4f6ff"
 
+generic-pool@2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.5.4.tgz#38c6188513e14030948ec6e5cf65523d9779299b"
+
 generic-pool@~2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.1.1.tgz#af04dc2c325cfcb975023fa52bfce9617a7435fd"
@@ -747,7 +750,7 @@ generic-pool@~2.2.0, generic-pool@~2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.2.2.tgz#7a89f491d575b42f9f069a0e8e2c6dbaa3c241be"
 
-generic-pool@~2.4.0, generic-pool@~2.4.1:
+generic-pool@~2.4.1:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.6.tgz#f1b55e572167dba2fe75d5aa91ebb1e9f72642d7"
 
@@ -1236,9 +1239,9 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-mapnik-vector-tile@cartodb/mapnik-vector-tile#v1.6.1-carto.1:
-  version "1.6.1-carto.1"
-  resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/0111f7117946179d62ec7a6eba2f4e9fb355d05e"
+"mapnik-vector-tile@github:cartodb/mapnik-vector-tile#v1.6.1-carto.2":
+  version "1.6.1-carto.2"
+  resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/e7ca5471f9e5de81243e6035e70444321fc0a82f"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1281,13 +1284,13 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mime@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
+
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
-
-mime@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
@@ -1596,7 +1599,7 @@ pg-types@1.*:
     postgres-date "~1.0.0"
     postgres-interval "^1.1.0"
 
-"pg@github:CartoDB/node-postgres#6.4.2-cdb1":
+pg@CartoDB/node-postgres#6.4.2-cdb1:
   version "6.4.2"
   resolved "https://codeload.github.com/CartoDB/node-postgres/tar.gz/449fac1d6da711ffcc6694ae3c89f85244f48bdc"
   dependencies:
@@ -1695,10 +1698,6 @@ progress-stream@~0.5.x:
     single-line-log "~0.3.1"
     speedometer "~0.1.2"
     through2 "~0.2.3"
-
-protozero@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/protozero/-/protozero-1.5.1.tgz#5a27df6fb6e1ed743f510812ae76c082f5b16638"
 
 proxy-addr@~2.0.3:
   version "2.0.3"
@@ -2066,7 +2065,7 @@ speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
 
-sphericalmercator@1.0.5, sphericalmercator@1.0.x, sphericalmercator@~1.0.1, sphericalmercator@~1.0.4:
+sphericalmercator@1.0.5, sphericalmercator@~1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sphericalmercator/-/sphericalmercator-1.0.5.tgz#ddc5a049e360e000d0fad9fc22c4071882584980"
 
@@ -2225,15 +2224,13 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb14:
-  version "0.6.18-cdb14"
-  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/6d06f728833d3e34d1adcd05567b3f4379f547bb"
+tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb15:
+  version "0.6.18-cdb15"
+  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/b6c1404a9e37fc60e545d977081867a86eb42b2b"
   dependencies:
-    "@carto/mapnik" "3.6.2-carto.10"
-    generic-pool "~2.4.0"
-    mime "~1.6.0"
-    sphericalmercator "~1.0.4"
-    step "~0.0.5"
+    "@carto/mapnik" "3.6.2-carto.11"
+    generic-pool "2.5.4"
+    mime "2.3.1"
 
 tilelive@5.12.3:
   version "5.12.3"


### PR DESCRIPTION
Groups https://github.com/CartoDB/Windshaft/pull/646 and https://github.com/CartoDB/Windshaft/pull/647

- Update deps:
  - `@carto/mapnik` to [`3.6.2-carto.11`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto.11/CHANGELOG.carto.md#362-carto11): Geometries in MVTs created with the mapnik renderer will be simplified based on the layer extent instead of a static 256. This has impact in lines and polygon layers, both in results and performance since geometries were being oversimplified.
  - `@carto/tilelive-bridge` to [`2.5.1-cdb10`](https://github.com/CartoDB/tilelive-bridge/blob/2.5.1-cdb10/CHANGELOG.carto.md#251-cdb10): MVT Mapnik renderer no longers returns error on empty tile, instead it returns an empty buffer.
  - `tilelive-mapnik` to [`0.6.18-cdb15`](https://github.com/CartoDB/tilelive-mapnik/blob/0.6.18-cdb15/CHANGELOG.carto.md#0618-cdb15): Removes internal use of step and eventEmitter. Also updates and removes some dependencies.
  - `abaculus` to [`2.0.3-cdb11`](https://github.com/CartoDB/abaculus/blob/2.0.3-cdb11/changelog.carto.md#203-cdb11): Keeping up with node-mapnik update.
- MVT renderers (both): No longer returns error on empty tile. Instead it returns an empty buffer.
- MVT renderers (both): Add `vector_extent` option in MapConfig to setup the layer extent in MVTs.
- MVT renderers (both): Add `vector_simplify_extent` option in MapConfig to configure the simplification process in MVTs.
- pg-mvt renderer: Include the buffer zone in the !bbox! variable.
- pg-mvt renderer: Fix bug that caused a buffer size of value 0 being ignored.


Closes #657 
Closes #641 
Closes #633