### PR TITLE
pg-mvt: Implement timeout in getTile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Version 4.10.0
+2018-XX-XX
+
+Announcements:
+- pg-mvt: Implement timeout in getTile.
+
+
 # Version 4.9.0
 2018-09-05
 

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -73,17 +73,16 @@ PgMvtFactory.prototype = {
             this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
         }
 
-        let map_extents = {};
+
         try {
-            map_extents = mapConfig.getMVTExtents();
+            const map_extents = mapConfig.getMVTExtents();
+            this.options.vector_extent = map_extents.extent;
+            this.options.vector_simplify_extent = map_extents.simplify_extent;
+
+            const mvt_renderer = new Renderer(layers, this.options, dbParams);
+            mvt_renderer.getAllLayerColumns(callback);
         } catch(err) {
             return callback(err);
         }
-
-        this.options.vector_extent = map_extents.extent;
-        this.options.vector_simplify_extent = map_extents.simplify_extent;
-
-        const mvt_renderer = new Renderer(layers, this.options, dbParams);
-        mvt_renderer.initDB(callback);
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -84,11 +84,6 @@ PgMvtFactory.prototype = {
         this.options.vector_simplify_extent = map_extents.simplify_extent;
 
         const mvt_renderer = new Renderer(layers, this.options, dbParams);
-        mvt_renderer.initDB((err, renderer) => {
-            if (err) {
-                return callback(err);
-            }
-            return callback(null, renderer);
-        });
+        mvt_renderer.initDB(callback);
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/factory.js
+++ b/lib/windshaft/renderers/pg-mvt/factory.js
@@ -1,12 +1,10 @@
 const _ = require('underscore');
-const PSQL = require('cartodb-psql');
 const layersFilter = require('../../utils/layer_filter');
 
 const RendererParams = require('../renderer_params');
 
 const Renderer = require('./renderer');
 const BaseAdaptor = require('../base_adaptor');
-const SubstitutionTokens = require('../../utils/substitution_tokens');
 
 /**
  * API: initializes the renderer, it should be called once
@@ -19,79 +17,6 @@ const SubstitutionTokens = require('../../utils/substitution_tokens');
  */
 function PgMvtFactory(options) {
     this.options = options || {};
-}
-
-
-function setDefaultTokens (sql) {
-    return SubstitutionTokens.replace(sql, {
-        bbox: `CDB_XYZ_Extent(0,0,0)`,
-        scale_denominator: `0`,
-        pixel_width: `0`,
-        pixel_height: `0`,
-        var_zoom: `0`,
-        var_x: `0`,
-        var_y: `0`
-    });
-}
-
-/**
- * Helper function to populate `layer._mvtColumns` with the columns to be
- * requested in the MVT tile SQL query
- * @param {Object} psql - Initialize cartodb-psql with the DB connection
- * @param {Object} layer - Map layers
- * @returns {Promise}
- */
-function getLayerColumns(psql, layer) {
-    return new Promise((resolve, reject) => {
-        if (layer._mvtColumns) {
-            return resolve();
-        }
-
-        if (!layer.options.sql) {
-            return reject("Missing sql for layer");
-        }
-
-        const layerSQL = setDefaultTokens(layer.options.sql, 0, 0, 0);
-        const limitedQuery = `SELECT * FROM (${layerSQL}) __windshaft_mvt_schema LIMIT 0;`;
-
-        psql.query(limitedQuery, function (err, data) {
-            if (err) {
-                if (err.message) {
-                    err.message = "PgMvtFactory: " + err.message;
-                }
-                return reject(err);
-            }
-
-            // We filter by type id to avoid the implicit casts that ST_AsMVT does
-            // from any unknown type to string
-            // These are the list of compatible type oids as declared in
-            // mapnik/plugins/input/postgis/postgis_datasource.cpp
-            const COMPATIBLE_MVT_TYPEIDS = [
-                16,     // bool
-                20,     // int8
-                21,     // int2
-                23,     // int4
-                700,    // float4
-                701,    // float8
-                1700,   // numeric
-                1042,   // bpchar
-                1043,   // varchar
-                25,     // text
-                705,    // literal
-            ];
-
-            const metadataColumns = [];
-            Object.keys(data.fields).forEach(function(key){
-                const val = data.fields[key];
-                if (COMPATIBLE_MVT_TYPEIDS.includes(val.dataTypeID)) {
-                    metadataColumns.push(val.name);
-                }
-            });
-            // We cache the column names to avoid requesting them again
-            layer._mvtColumns = metadataColumns;
-            return resolve();
-        });
-    });
 }
 
 module.exports = PgMvtFactory;
@@ -143,7 +68,6 @@ PgMvtFactory.prototype = {
         const layers = filteredLayers.map(layerIndex => mapConfig.getLayer(layerIndex));
         let dbParams = RendererParams.dbParamsFromReqParams(options.params);
         _.extend(dbParams, mapConfig.getLayerDatasource(options.layer));
-        const psql = new PSQL(dbParams, this.options.dbPoolParams);
 
         if (Number.isFinite(mapConfig.getBufferSize(MVT_FORMAT))) {
             this.options.bufferSize = mapConfig.getBufferSize(MVT_FORMAT);
@@ -159,9 +83,12 @@ PgMvtFactory.prototype = {
         this.options.vector_extent = map_extents.extent;
         this.options.vector_simplify_extent = map_extents.simplify_extent;
 
-        const columnNamePromises = layers.map(layer => getLayerColumns(psql, layer));
-        Promise.all(columnNamePromises)
-        .then(() => callback(null, new Renderer(layers, psql, {}, this.options)))
-        .catch(err => callback(err));
+        const mvt_renderer = new Renderer(layers, this.options, dbParams);
+        mvt_renderer.initDB((err, renderer) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, renderer);
+        });
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -139,7 +139,7 @@ module.exports = class PostgresVectorRenderer {
         this.psql = new PSQL(this.dbParams, this.dbPoolParams);
     }
 
-    // Init DB and get layer column names.
+    // Retrieve the columns of all layers for later usage when requesting tiles
     getAllLayerColumns (callback) {
         const columnNamePromises = this.layers.map(layer => getLayerColumns(this.psql, layer));
         Promise.all(columnNamePromises)

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -1,6 +1,7 @@
-const Timer = require('../../stats/timer');
 const debug = require('debug')('windshaft:renderer:pg_mvt');
+const PSQL = require('cartodb-psql');
 const SubstitutionTokens = require('../../utils/substitution_tokens');
+const Timer = require('../../stats/timer');
 
 function shouldUseLayer(layer, zoom) {
     const minZoom = Number.isFinite(layer.options.minzoom) ? layer.options.minzoom : 0;
@@ -20,16 +21,89 @@ function extractMVT(data) {
     return null;
 }
 
+function setDefaultTokens (sql) {
+    return SubstitutionTokens.replace(sql, {
+        bbox: `CDB_XYZ_Extent(0,0,0)`,
+        scale_denominator: `0`,
+        pixel_width: `0`,
+        pixel_height: `0`,
+        var_zoom: `0`,
+        var_x: `0`,
+        var_y: `0`
+    });
+}
+
+/**
+ * Helper function to populate `layer._mvtColumns` with the columns to be
+ * requested in the MVT tile SQL query
+ * @param {Object} psql - Initialize cartodb-psql with the DB connection
+ * @param {Object} layer - Map layers
+ * @returns {Promise}
+ */
+function getLayerColumns(psql, layer) {
+    return new Promise((resolve, reject) => {
+        if (layer._mvtColumns) {
+            return resolve();
+        }
+
+        if (!layer.options.sql) {
+            return reject("Missing sql for layer");
+        }
+
+        const layerSQL = setDefaultTokens(layer.options.sql, 0, 0, 0);
+        const limitedQuery = `SELECT * FROM (${layerSQL}) __windshaft_mvt_schema LIMIT 0;`;
+
+        psql.query(limitedQuery, function (err, data) {
+            if (err) {
+                if (err.message) {
+                    err.message = "PgMvtFactory: " + err.message;
+                }
+                return reject(err);
+            }
+
+            // We filter by type id to avoid the implicit casts that ST_AsMVT does
+            // from any unknown type to string
+            // These are the list of compatible type oids as declared in
+            // mapnik/plugins/input/postgis/postgis_datasource.cpp
+            const COMPATIBLE_MVT_TYPEIDS = [
+                16,     // bool
+                20,     // int8
+                21,     // int2
+                23,     // int4
+                700,    // float4
+                701,    // float8
+                1700,   // numeric
+                1042,   // bpchar
+                1043,   // varchar
+                25,     // text
+                705,    // literal
+            ];
+
+            const metadataColumns = [];
+            Object.keys(data.fields).forEach(function(key){
+                const val = data.fields[key];
+                if (COMPATIBLE_MVT_TYPEIDS.includes(val.dataTypeID)) {
+                    metadataColumns.push(val.name);
+                }
+            });
+            // We cache the column names to avoid requesting them again
+            layer._mvtColumns = metadataColumns;
+            return resolve();
+        });
+    });
+}
+
 /// CLASS: pg_mvt Renderer
 //
 /// A renderer for a given MapConfig layer
 ///
 module.exports = class PostgresVectorRenderer {
 
-    constructor (layers, psql, attrs, options = {}) {
-        this.psql = psql;
-        this.attrs = attrs;
+    constructor (layers, options = {}, dbParams = {}) {
         this.layers = layers;
+        this.dbParams = dbParams;
+        this.dbPoolParams = options.dbPoolParams;
+        this.psql = undefined;
 
         this.tile_size = 256;
         this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
@@ -37,6 +111,20 @@ module.exports = class PostgresVectorRenderer {
         this.vector_extent = options.vector_extent;
         this.vector_simplify_extent = options.vector_simplify_extent;
         this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);
+    }
+
+    // Init DB and get layer column names.
+    initDB (callback) {
+        try {
+            this.psql = new PSQL(this.dbParams, this.dbPoolParams);
+        } catch (err) {
+            return callback(err);
+        }
+
+        const columnNamePromises = this.layers.map(layer => getLayerColumns(this.psql, layer));
+        Promise.all(columnNamePromises)
+        .then(() => callback(null, this))
+        .catch(err => callback(err));
     }
 
     /// API: renders a tile with the Renderer configuration
@@ -54,7 +142,6 @@ module.exports = class PostgresVectorRenderer {
         if (subqueries.length === 0) {
             return callback(null, new Buffer(0), headers);
         }
-
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
         const timer = new Timer();

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -147,66 +147,32 @@ module.exports = class PostgresVectorRenderer {
         .catch(err => callback(err));
     }
 
-    _getTileTimeout (z, x, y, timeoutMs, callback) {
-        const headers = {
-            'Content-Type': 'application/x-protobuf',
-            'x-tilelive-contains-data' : false
-        };
-        const subqueries = this._getLayerQueries({ z, x, y });
-        if (subqueries.length === 0) {
-            return callback(null, new Buffer(0), headers);
-        }
-
-        const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
-
-        const getTilePr = new Promise((resolve, reject) => {
-
-            const timer = new Timer();
-            timer.start('query');
-
-            this.psql.query(query, function (err, data) {
-                timer.end('query');
-                if (err) {
-                    debug("Error running pg-mvt query " + query + ": " + err);
-                    if (err.message) {
-                        err.message = "PgMvtRenderer: " + err.message;
-                    }
-                    return reject(err);
-                }
-
-                const mvt = extractMVT(data);
-                if (mvt) {
-                    headers['x-tilelive-contains-data'] = true;
-                }
-                const stats = timer.getTimes();
-
-                return resolve([mvt || new Buffer(0), headers, stats]);
-            });
-        });
-
-        // Matching tilelive-bridge timeout-decorator.js string
-        const TIMEOUT_ERROR_MSG = 'Render timed out';
-        const promises = [getTilePr];
-        if (timeoutMs) {
-            promises.push(new Promise((resolve, reject) =>
-                setTimeout(reject, timeoutMs, new Error(TIMEOUT_ERROR_MSG))
-            ));
-        }
-
-        Promise.race(promises)
-        .then(([mvt, headers, stats]) => callback(null, mvt, headers, stats))
-        .catch(err => {
-            cancelQuery(query, this.dbParams, this.dbPoolParams, () => callback(err));
-        });
-    }
-
     /// API: renders a tile with the Renderer configuration
     /// @param x tile x coordinate
     /// @param y tile y coordinate
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        return this._getTileTimeout(z, x, y, this.renderLimit, callback);
+        const subqueries = this._getLayerQueries({ z, x, y });
+        if (subqueries.length === 0) {
+            return callback(null, new Buffer(0), { 'Content-Type': 'application/x-protobuf',
+                                                   'x-tilelive-contains-data' : false });
+        }
+
+        const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
+        const promises = [this._getTilePromise(query)];
+
+        // Matching tilelive-bridge timeout-decorator.js string
+        const TIMEOUT_ERROR_MSG = 'Render timed out';
+        if (this.renderLimit) {
+            promises.push(new Promise((resolve, reject) =>
+                setTimeout(reject, this.renderLimit, new Error(TIMEOUT_ERROR_MSG))
+            ));
+        }
+
+        Promise.race(promises)
+        .then(([mvt, headers, stats]) => callback(null, mvt, headers, stats))
+        .catch(err => cancelQuery(query, this.dbParams, this.dbPoolParams, () => callback(err)));
     }
 
     _getLayerQueries({ z, x, y }) {
@@ -259,5 +225,32 @@ module.exports = class PostgresVectorRenderer {
                     WHERE ${geomColumn} && !bbox!
                 ) AS geometries
                 `, { z, x, y });
+    }
+
+    _getTilePromise (query) {
+        return new Promise((resolve, reject) => {
+
+            const timer = new Timer();
+            timer.start('query');
+
+            this.psql.query(query, function (err, data) {
+                timer.end('query');
+                if (err) {
+                    debug("Error running pg-mvt query " + query + ": " + err);
+                    if (err.message) {
+                        err.message = "PgMvtRenderer: " + err.message;
+                    }
+                    return reject(err);
+                }
+
+                const mvt = extractMVT(data);
+                const headers = { 'Content-Type': 'application/x-protobuf' };
+                headers['x-tilelive-contains-data'] = mvt !== null;
+
+                const stats = timer.getTimes();
+
+                return resolve([mvt || new Buffer(0), headers, stats]);
+            });
+        });
     }
 };

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -151,7 +151,6 @@ module.exports = class PostgresVectorRenderer {
         .catch(err => callback(err));
     }
 
-    // Returns a promise
     _getTileTimeout (z, x, y, timeout_ms, callback) {
         const headers = {
             'Content-Type': 'application/x-protobuf',

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -30,14 +30,14 @@ function setDefaultTokens (sql) {
     });
 }
 
-function cancelQuery (query_str, dbParams, dbPoolParams, callback)
+function cancelQuery (query, dbParams, dbPoolParams, callback)
 {
     let pg;
     try {
         pg = new PSQL(dbParams, dbPoolParams);
     } catch (err) { return callback(); }
 
-    const getPIDQuery = "SELECT pid FROM pg_stat_activity WHERE query LIKE $cancelQuery$" + query_str + "$cancelQuery$";
+    const getPIDQuery = "SELECT pid FROM pg_stat_activity WHERE query LIKE $cancelQuery$" + query + "$cancelQuery$";
     pg.query(getPIDQuery, (err, result) => {
         if (err) { pg.end(); return callback(); }
 
@@ -59,7 +59,7 @@ function cancelQuery (query_str, dbParams, dbPoolParams, callback)
 /**
  * Helper function to populate `layer._mvtColumns` with the columns to be
  * requested in the MVT tile SQL query
- * @param {Object} psql - Initialize cartodb-psql with the DB connection
+ * @param {Object} psql - Initialized cartodb-psql with the DB connection
  * @param {Object} layer - Map layers
  * @returns {Promise}
  */
@@ -127,14 +127,14 @@ module.exports = class PostgresVectorRenderer {
         this.dbParams = dbParams;
         this.dbPoolParams = options.dbPoolParams;
         this.psql = undefined;
-        this.render_limit = options.limits ? options.limits.render || 0 : 0;
+        this.renderLimit = options.limits ? options.limits.render || 0 : 0;
 
-        this.tile_size = 256;
-        this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
-        this.buffer_size = options.hasOwnProperty('bufferSize') ? options.bufferSize : 64; // Same as Mapnik::bufferSize
-        this.vector_extent = options.vector_extent;
-        this.vector_simplify_extent = options.vector_simplify_extent;
-        this.subpixelBufferSize = Math.round(this.buffer_size * this.vector_extent / this.tile_size);
+        this.tileSize = 256;
+        this.tileMaxGeosize = 40075017; // earth circumference in webmercator 3857
+        this.bufferSize = options.hasOwnProperty('bufferSize') ? options.bufferSize : 64; // Same as Mapnik::bufferSize
+        this.vectorExtent = options.vector_extent;
+        this.vectorSimplifyExtent = options.vector_simplify_extent;
+        this.subpixelBufferSize = Math.round(this.bufferSize * this.vectorExtent / this.tileSize);
     }
 
     // Init DB and get layer column names.
@@ -151,7 +151,7 @@ module.exports = class PostgresVectorRenderer {
         .catch(err => callback(err));
     }
 
-    _getTileTimeout (z, x, y, timeout_ms, callback) {
+    _getTileTimeout (z, x, y, timeoutMs, callback) {
         const headers = {
             'Content-Type': 'application/x-protobuf',
             'x-tilelive-contains-data' : false
@@ -163,7 +163,7 @@ module.exports = class PostgresVectorRenderer {
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
 
-        const pr_getTile = new Promise((resolve, reject) => {
+        const getTilePr = new Promise((resolve, reject) => {
 
             const timer = new Timer();
             timer.start('query');
@@ -190,10 +190,10 @@ module.exports = class PostgresVectorRenderer {
 
         // Matching tilelive-bridge timeout-decorator.js string
         const TIMEOUT_ERROR_MSG = 'Render timed out';
-        const promises = [pr_getTile];
-        if (timeout_ms) {
+        const promises = [getTilePr];
+        if (timeoutMs) {
             promises.push(new Promise((resolve, reject) =>
-                setTimeout(reject, timeout_ms, new Error(TIMEOUT_ERROR_MSG))
+                setTimeout(reject, timeoutMs, new Error(TIMEOUT_ERROR_MSG))
             ));
         }
 
@@ -210,7 +210,7 @@ module.exports = class PostgresVectorRenderer {
     /// @param z tile zoom
     /// callback: will be called when done using nodejs protocol (err, data)
     getTile (z, x, y, callback) {
-        return this._getTileTimeout(z, x, y, this.render_limit, callback);
+        return this._getTileTimeout(z, x, y, this.renderLimit, callback);
     }
 
     _getLayerQueries({ z, x, y }) {
@@ -224,14 +224,14 @@ module.exports = class PostgresVectorRenderer {
 
     _geomColumn (layer, { z = 0, x = 0, y = 0 }) {
         let geomColumn = layer.options.geom_column || 'the_geom_webmercator';
-        if (this.vector_extent !== this.vector_simplify_extent) {
-            const tol = (this.tile_max_geosize / Math.pow(2, z)) / (this.vector_simplify_extent * 2);
+        if (this.vectorExtent !== this.vectorSimplifyExtent) {
+            const tol = (this.tileMaxGeosize / Math.pow(2, z)) / (this.vectorSimplifyExtent * 2);
             geomColumn = `ST_Simplify(ST_RemoveRepeatedPoints(${geomColumn}, ${tol}), ${tol}, true)`;
         }
         return `ST_AsMVTGeom(
                     ${geomColumn},
                     CDB_XYZ_Extent(${x},${y},${z}),
-                    ${this.vector_extent},
+                    ${this.vectorExtent},
                     ${this.subpixelBufferSize},
                     true
                 ) as the_geom_webmercator`;
@@ -241,12 +241,12 @@ module.exports = class PostgresVectorRenderer {
         return SubstitutionTokens.replace(sql, {
             bbox: `ST_Expand(
                             CDB_XYZ_Extent(${x},${y},${z}),
-                            CDB_XYZ_Resolution(${z}) * ${Math.round(256 * this.buffer_size / this.tile_size)}
+                            CDB_XYZ_Resolution(${z}) * ${Math.round(256 * this.bufferSize / this.tileSize)}
                         )`,
             // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
-            scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric *${256 / this.tile_size / 0.00028})`,
-            pixel_width: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
-            pixel_height: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`
+            scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric *${256 / this.tileSize / 0.00028})`,
+            pixel_width: `cdb_XYZ_Resolution(${z})*${256 / this.tileSize}`,
+            pixel_height: `cdb_XYZ_Resolution(${z})*${256 / this.tileSize}`
         });
     }
 
@@ -256,7 +256,7 @@ module.exports = class PostgresVectorRenderer {
         const columnList = !columns ? '' : `, "${columns.join('", "')}"`;
 
         return this._replaceTokens(
-                `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vector_extent}, 'the_geom_webmercator')
+                `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vectorExtent}, 'the_geom_webmercator')
                 FROM (
                     SELECT ${geometryColumn}${columnList}
                     FROM (${query}) AS cdbq

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -30,6 +30,32 @@ function setDefaultTokens (sql) {
     });
 }
 
+function cancelQuery (query_str, dbParams, dbPoolParams, callback)
+{
+    let pg;
+    try {
+        pg = new PSQL(dbParams, dbPoolParams);
+    } catch (err) { return callback(); }
+
+    const getPIDQuery = "SELECT pid FROM pg_stat_activity WHERE query LIKE $cancelQuery$" + query_str + "$cancelQuery$";
+    pg.query(getPIDQuery, (err, result) => {
+        if (err) { pg.end(); return callback(); }
+
+        if (!result.rows[0] || !result.rows[0].pid) {
+            pg.end();
+            return callback();
+        }
+
+        const pid = result.rows[0].pid;
+        const cancelQuery = 'SELECT pg_cancel_backend(' + pid + ')';
+
+        pg.query(cancelQuery, () => {
+            pg.end();
+            callback();
+        });
+    });
+}
+
 /**
  * Helper function to populate `layer._mvtColumns` with the columns to be
  * requested in the MVT tile SQL query
@@ -175,8 +201,7 @@ module.exports = class PostgresVectorRenderer {
         Promise.race(promises)
         .then(([mvt, headers, stats]) => callback(null, mvt, headers, stats))
         .catch(err => {
-            // TODO: Cancel query
-            return callback(err);
+            cancelQuery(query, this.dbParams, this.dbPoolParams, () => callback(err));
         });
     }
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -101,6 +101,7 @@ module.exports = class PostgresVectorRenderer {
         this.dbParams = dbParams;
         this.dbPoolParams = options.dbPoolParams;
         this.psql = undefined;
+        this.render_limit = options.limits ? options.limits.render || 0 : 0;
 
         this.tile_size = 256;
         this.tile_max_geosize = 40075017; // earth circumference in webmercator 3857
@@ -124,44 +125,68 @@ module.exports = class PostgresVectorRenderer {
         .catch(err => callback(err));
     }
 
-    /// API: renders a tile with the Renderer configuration
-    /// @param x tile x coordinate
-    /// @param y tile y coordinate
-    /// @param z tile zoom
-    /// callback: will be called when done using nodejs protocol (err, data)
-    getTile (z, x, y, callback) {
+    // Returns a promise
+    _getTileTimeout (z, x, y, timeout_ms, callback) {
         const headers = {
             'Content-Type': 'application/x-protobuf',
             'x-tilelive-contains-data' : false
         };
-
         const subqueries = this._getLayerQueries({ z, x, y });
         if (subqueries.length === 0) {
             return callback(null, new Buffer(0), headers);
         }
 
         const query = `SELECT ((${subqueries.join(') || (')})) AS st_asmvt`;
-        const timer = new Timer();
 
-        timer.start('query');
-        this.psql.query(query, function (err, data) {
-            timer.end('query');
-            if (err) {
-                debug("Error running pg-mvt query " + query + ": " + err);
-                if (err.message) {
-                    err.message = "PgMvtRenderer: " + err.message;
+        const pr_getTile = new Promise((resolve, reject) => {
+
+            const timer = new Timer();
+            timer.start('query');
+
+            this.psql.query(query, function (err, data) {
+                timer.end('query');
+                if (err) {
+                    debug("Error running pg-mvt query " + query + ": " + err);
+                    if (err.message) {
+                        err.message = "PgMvtRenderer: " + err.message;
+                    }
+                    return reject(err);
                 }
-                return callback(err);
-            }
 
-            const mvt = extractMVT(data);
-            if (mvt) {
-                headers['x-tilelive-contains-data'] = true;
-            }
-            const stats = timer.getTimes();
+                const mvt = extractMVT(data);
+                if (mvt) {
+                    headers['x-tilelive-contains-data'] = true;
+                }
+                const stats = timer.getTimes();
 
-            return callback(null, mvt || new Buffer(0), headers, stats);
+                return resolve([mvt || new Buffer(0), headers, stats]);
+            });
         });
+
+        // Matching tilelive-bridge timeout-decorator.js string
+        const TIMEOUT_ERROR_MSG = 'Render timed out';
+        const promises = [pr_getTile];
+        if (timeout_ms) {
+            promises.push(new Promise((resolve, reject) =>
+                setTimeout(reject, timeout_ms, new Error(TIMEOUT_ERROR_MSG))
+            ));
+        }
+
+        Promise.race(promises)
+        .then(([mvt, headers, stats]) => callback(null, mvt, headers, stats))
+        .catch(err => {
+            // TODO: Cancel query
+            return callback(err);
+        });
+    }
+
+    /// API: renders a tile with the Renderer configuration
+    /// @param x tile x coordinate
+    /// @param y tile y coordinate
+    /// @param z tile zoom
+    /// callback: will be called when done using nodejs protocol (err, data)
+    getTile (z, x, y, callback) {
+        return this._getTileTimeout(z, x, y, this.render_limit, callback);
     }
 
     _getLayerQueries({ z, x, y }) {

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -26,10 +26,7 @@ function setDefaultTokens (sql) {
         bbox: `CDB_XYZ_Extent(0,0,0)`,
         scale_denominator: `0`,
         pixel_width: `0`,
-        pixel_height: `0`,
-        var_zoom: `0`,
-        var_x: `0`,
-        var_y: `0`
+        pixel_height: `0`
     });
 }
 
@@ -200,10 +197,7 @@ module.exports = class PostgresVectorRenderer {
             // See https://github.com/mapnik/mapnik/wiki/ScaleAndPpi#scale-denominator
             scale_denominator: `(cdb_XYZ_Resolution(${z})::numeric *${256 / this.tile_size / 0.00028})`,
             pixel_width: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
-            pixel_height: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`,
-            var_zoom: z,
-            var_x: x,
-            var_y: y
+            pixel_height: `cdb_XYZ_Resolution(${z})*${256 / this.tile_size}`
         });
     }
 

--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -126,7 +126,6 @@ module.exports = class PostgresVectorRenderer {
         this.layers = layers;
         this.dbParams = dbParams;
         this.dbPoolParams = options.dbPoolParams;
-        this.psql = undefined;
         this.renderLimit = options.limits ? options.limits.render || 0 : 0;
 
         this.tileSize = 256;
@@ -135,16 +134,13 @@ module.exports = class PostgresVectorRenderer {
         this.vectorExtent = options.vector_extent;
         this.vectorSimplifyExtent = options.vector_simplify_extent;
         this.subpixelBufferSize = Math.round(this.bufferSize * this.vectorExtent / this.tileSize);
+
+        // May throw
+        this.psql = new PSQL(this.dbParams, this.dbPoolParams);
     }
 
     // Init DB and get layer column names.
-    initDB (callback) {
-        try {
-            this.psql = new PSQL(this.dbParams, this.dbPoolParams);
-        } catch (err) {
-            return callback(err);
-        }
-
+    getAllLayerColumns (callback) {
         const columnNamePromises = this.layers.map(layer => getLayerColumns(this.psql, layer));
         Promise.all(columnNamePromises)
         .then(() => callback(null, this))

--- a/lib/windshaft/renderers/renderer_factory.js
+++ b/lib/windshaft/renderers/renderer_factory.js
@@ -16,7 +16,7 @@ function RendererFactory(opts) {
     opts.torque = opts.torque || {};
     opts.mvt = opts.mvt || {};
     if (opts.mapnik.mapnik) {
-        opts.mvt.limits = opts.mapnik.mapnik.limits || {};
+        opts.mvt.limits = opts.mapnik.mapnik.limits;
     }
     this.opts = opts;
 

--- a/lib/windshaft/renderers/renderer_factory.js
+++ b/lib/windshaft/renderers/renderer_factory.js
@@ -15,6 +15,9 @@ function RendererFactory(opts) {
     opts.mapnik = opts.mapnik || {};
     opts.torque = opts.torque || {};
     opts.mvt = opts.mvt || {};
+    if (opts.mapnik.mapnik) {
+        opts.mvt.limits = opts.mapnik.mapnik.limits || {};
+    }
     this.opts = opts;
 
     this.mapnikRendererFactory = new MapnikRenderer.factory(opts.mapnik);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "4.9.0",
+    "version": "4.10.0",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [

--- a/test/prepare_test
+++ b/test/prepare_test
@@ -52,6 +52,11 @@ createdb -EUTF8 windshaft_test || die "Could not create test database"
 psql -c 'create extension postgis' windshaft_test ||
   die "Could not install postgis in test database"
 
+if [ $POSTGIS_VERSION -ge 30000 ]; then
+    echo "Postgis 3+ detected: Installing Postgis Raster extension too"
+    psql -c 'create extension postgis_raster' windshaft_test ||  die "Could not install postgis_raster"
+fi
+
 for i in CDB_XYZ CDB_QueryStatements CDB_QueryTables
 do
   echo "...Installing $i"


### PR DESCRIPTION
Since you need to open a new connection to close a running query I had to move the connection parameters to the renderer, so I decided to move `getLayerColumns` too and add a `initDB` function to avoid handling promises in the constructor.

To get the limits inside this renderer I've modified the factory to add `mapnik.mapnik.limits` to `mvt`, which is not pretty but needed for compatibility.

Closes #577 
Closes #624