### PR TITLE
pg-mvt: ignore semicolon

### DIFF
--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -31,6 +31,11 @@ function setDefaultTokens (sql) {
     });
 }
 
+function removeTrailingSemiColon(sql) {
+    return sql.replace(/\s*;\s*$/, '');
+}
+
+
 function cancelQuery (query, dbParams, dbPoolParams, callback)
 {
     let pg;
@@ -74,7 +79,7 @@ function getLayerColumns(psql, layer) {
             return reject("Missing sql for layer");
         }
 
-        const layerSQL = setDefaultTokens(layer.options.sql, 0, 0, 0);
+        const layerSQL = setDefaultTokens(removeTrailingSemiColon(layer.options.sql), 0, 0, 0);
         const limitedQuery = `SELECT * FROM (${layerSQL}) __windshaft_mvt_schema LIMIT 0;`;
 
         psql.query(limitedQuery, function (err, data) {
@@ -228,7 +233,7 @@ module.exports = class PostgresVectorRenderer {
             layer.options.query_rewrite_data :
             undefined;
 
-        query = this.queryRewriter.query(query, queryRewriteData);
+        query = this.queryRewriter.query(removeTrailingSemiColon(query), queryRewriteData);
 
         return this._replaceTokens(
                 `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vectorExtent}, 'the_geom_webmercator')

--- a/test/acceptance/mvt.js
+++ b/test/acceptance/mvt.js
@@ -79,6 +79,30 @@ function mvtTest(usePostGIS) {
         });
     });
 
+    it('single layer and the query has a semicolon', function (done) {
+        const sql = "select cartodb_id, the_geom_webmercator from test_table \n\t ;   ";
+        const mapConfig = TestClient.mvtLayerMapConfig(sql, 'the_geom_webmercator', 3857);
+        const testClient = new TestClient(mapConfig, options);
+
+        testClient.getTile(13, 4011, 3088, { layer: 'mapnik', format: 'mvt' }, function (err, mvtTile) {
+            if (err) {
+                return done(err);
+            }
+
+            const vectorTile = new mapnik.VectorTile(13, 4011, 3088);
+
+            vectorTile.setData(mvtTile);
+            assert.equal(vectorTile.painted(), true);
+            assert.equal(vectorTile.empty(), false);
+
+            const result = vectorTile.toJSON();
+
+            assert.equal(result.length, 1);
+
+            done();
+        });
+    });
+
     it('single layer and the query retrieves `the_geom_webmercator` only', function (done) {
         if (!usePostGIS) {
             return done();


### PR DESCRIPTION
This removes the trailing semicolon from the input query so that it can be composed in subqueries, just like mapnik renderer does internally.