### PR TITLE
Update cartodb-psql to version 0.13.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Version 4.12.1
-2018-mm-dd
+2018-12-dd
+
+Announcements:
+ - Update cartodb-psql to 0.13.1
 
 # Version 4.12.0
 2018-11-21

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,9 +271,9 @@
             }
         },
         "cartodb-psql": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.13.0.tgz",
-            "integrity": "sha512-+MBxpgijBgSgXciuwUMGedVB1lABToySoxipODB8YasRc3X15oVSSku9WcMYICnZZg1x2b2Sq4POazBAYoVHxA==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.13.1.tgz",
+            "integrity": "sha512-1z3Dk9G8KQlNGurbcmGBvNj8DVCh1Keue9uzyyvB6hKOYzBHMxixAMG0D+8nSsA7oQmWUsx/xkZZ5ZxT9toEHA==",
             "requires": {
                 "debug": "^3.1.0",
                 "pg": "github:cartodb/node-postgres#5417d7b29b7272ca2e71bb396899ab3f177a9ae6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "abaculus": "github:cartodb/abaculus#2.0.3-cdb13",
         "canvas": "github:cartodb/node-canvas#1.6.2-cdb3",
         "carto": "github:cartodb/carto#0.15.1-cdb5",
-        "cartodb-psql": "0.13.0",
+        "cartodb-psql": "0.13.1",
         "debug": "3.1.0",
         "dot": "1.1.2",
         "grainstore": "1.10.0",


### PR DESCRIPTION
Related to CartoDB/node-cartodb-psql#38 and similar to what was done for the SQL API.