### PR TITLE
[WIP] Avoid using static variables in BlendFactory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 XXXX-XX-XX
 
 Announcements:
-- 
+- Avoid using static variables in BlendFactory.
 
 # Version 5.2.1
 2019-05-21

--- a/lib/windshaft/renderers/blend/factory.js
+++ b/lib/windshaft/renderers/blend/factory.js
@@ -16,7 +16,10 @@ module.exports = BlendFactory;
 const NAME = 'blend';
 module.exports.NAME = NAME;
 
-var EMPTY_IMAGE_BUFFER = new mapnik.Image(256, 256).encodeSync('png');
+function empty_image_buffer()
+{
+    return new mapnik.Image(256, 256).encodeSync('png');
+}
 
 BlendFactory.prototype.getName = function() {
     return NAME;
@@ -81,12 +84,12 @@ BlendFactory.prototype.getRenderer = function(mapConfig, format, options, callba
                     if (err.code === 'ETIMEDOUT') {
                         return callback(err, tile, headers, stats);
                     }
-                    return callback(null, EMPTY_IMAGE_BUFFER, {'Content-Type': 'image/png'}, stats || {});
+                    return callback(null, empty_image_buffer(), {'Content-Type': 'image/png'}, stats || {});
                 };
             } else {
                 rendererOptions.onTileErrorStrategy = function(err, tile, headers, stats, format, callback) {
                     if (err.message && err.message.match(/coordinates out of range/i)) {
-                        return callback(null, EMPTY_IMAGE_BUFFER, {'Content-Type': 'image/png'}, stats || {});
+                        return callback(null, empty_image_buffer(), {'Content-Type': 'image/png'}, stats || {});
                     }
                     return callback(err, tile, headers, stats);
                 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "5.2.1",
+    "version": "5.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This doesn't have almost any impact, but makes it easier to debug memory issues:
```
==27341== 334 bytes in 1 blocks are still reachable in loss record 897 of 1,118
==27341==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==27341==    by 0x5D1674: UncheckedRealloc<char> (util-inl.h:348)
==27341==    by 0x5D1674: UncheckedMalloc<char> (util-inl.h:363)
==27341==    by 0x5D1674: UncheckedMalloc (util-inl.h:397)
==27341==    by 0x5D1674: node::Buffer::Copy(node::Environment*, char const*, unsigned long) (node_buffer.cc:344)
==27341==    by 0x5D17F9: node::Buffer::Copy(v8::Isolate*, char const*, unsigned long) (node_buffer.cc:327)
==27341==    by 0x10A8648A: CopyBuffer (nan.h:907)
==27341==    by 0x10A8648A: Image::encodeSync(Nan::FunctionCallbackInfo<v8::Value> const&) (mapnik_image.cpp:3703)
==27341==    by 0x10A185A5: Nan::imp::FunctionCallbackWrapper(v8::FunctionCallbackInfo<v8::Value> const&) (nan_callbacks_12_inl.h:176)
==27341==    by 0x817F2E: Call (api-arguments-inl.h:94)
==27341==    by 0x817F2E: v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) (builtins-api.cc:109)
==27341==    by 0x819515: v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) (builtins-api.cc:139)
==27341==    by 0x11890B6DBE1C: ???
==27341==    by 0x11890B6918D4: ???
==27341==    by 0x11890B6918D4: ???
==27341==    by 0x11890B6918D4: ???
==27341==    by 0x11890B6918D4: ???
```