### PR TITLE
Return empty array instead of null

### DIFF
--- a/lib/windshaft/metadata/layer-metadata.js
+++ b/lib/windshaft/metadata/layer-metadata.js
@@ -27,7 +27,7 @@ LayerMetadata.prototype.getMetadata = function (rendererCache, params, mapConfig
         .filter(metadataParam => metadataParam !== null);
 
     if (!metadataParams.length) {
-        return callback(null, null);
+        return callback(null, []);
     }
 
     return Promise.all(metadataParams.map(({ getMetadata, mapConfig, layer, layerId, params, rendererCache }) => {


### PR DESCRIPTION
As windshaft-cartodb expects when there is no layer metadata