### PR TITLE
Remove unneeded `the_geom_webmercator` param from ST_AsMVT

### DIFF
--- a/lib/windshaft/renderers/pg-mvt/renderer.js
+++ b/lib/windshaft/renderers/pg-mvt/renderer.js
@@ -240,7 +240,7 @@ module.exports = class PostgresVectorRenderer {
         query = this.queryRewriter.query(removeTrailingSemiColon(query), queryRewriteData);
 
         return this._replaceTokens(
-                `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vectorExtent}, 'the_geom_webmercator')
+                `SELECT ST_AsMVT(geometries, '${layerId}', ${this.vectorExtent})
                 FROM (
                     SELECT ${geometryColumn}${columnList}
                     FROM (${query}) AS cdbq


### PR DESCRIPTION
That parameter is not needed. As per the documentation:

> geom_name is the name of the geometry column in the row
> data. Default is the first geometry column.

This will let us push-down the whole ST_AsMVT expression to foreign
servers through FDW's.