### PR TITLE
Logging redis errors of MapStore

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Version 5.6.4
+2019-10-28
+
+Announcements:
+- Adding logs of Redis errors in MapStore. More info https://github.com/CartoDB/Windshaft/pull/708
+
 # Version 5.6.3
 2019-09-16
 

--- a/lib/windshaft/storages/mapstore.js
+++ b/lib/windshaft/storages/mapstore.js
@@ -161,7 +161,7 @@ o.log = function(err, command, args=[]) {
       args
     };
     this.logger.error(JSON.stringify(log));
-  };
-}
+  }
+};
 
 module.exports = MapStore;

--- a/lib/windshaft/storages/mapstore.js
+++ b/lib/windshaft/storages/mapstore.js
@@ -159,9 +159,9 @@ o.log = function(err, command, args=[]) {
       error: err.message,
       command,
       args
-    }
-    this.logger.error(JSON.stringify(log))
-  }
+    };
+    this.logger.error(JSON.stringify(log));
+  };
 }
 
 module.exports = MapStore;

--- a/lib/windshaft/storages/mapstore.js
+++ b/lib/windshaft/storages/mapstore.js
@@ -34,6 +34,7 @@ function MapStore(opts) {
     };
     this.redis_pool = new RedisPool(redis_opts);
   }
+  this.logger = opts.logger;
 }
 
 var o = MapStore.prototype;
@@ -61,11 +62,16 @@ o._redisCmd = function(func, args, callback) {
 
   pool.acquire(db, (err, client) => {
     if (err) {
+      this.log(err, 'adquiring client');
       return callback(err);
     }
 
     client[func](...args, (err, data) => {
       pool.release(db, client);
+
+      if (err) {
+        this.log(err, func, args);
+      }
 
       if (callback) {
         if (err) {
@@ -147,5 +153,15 @@ o.del = function(id, callback) {
   this._redisCmd('DEL', [key], callback);
 };
 
+o.log = function(err, command, args=[]) {
+  if (this.logger) {
+    const log = {
+      error: err.message,
+      command,
+      args
+    }
+    this.logger.error(JSON.stringify(log))
+  }
+}
 
 module.exports = MapStore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "5.6.3",
+    "version": "5.6.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "windshaft",
-    "version": "5.6.3",
+    "version": "5.6.4",
     "main": "./lib/windshaft/index.js",
     "description": "A Node.js map tile server for PostGIS with CartoCSS styling",
     "keywords": [


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/2177

The idea is to put this in production, gather stats and then remove it. Do you think I should do it with a more general-purpose?